### PR TITLE
When the default config is missing don't crash

### DIFF
--- a/commands/configure.go
+++ b/commands/configure.go
@@ -129,7 +129,7 @@ func PrepareConfigurationMigration(dir string) (func() bool, func() error) {
 		reader := bufio.NewReader(os.Stdin)
 		fmt.Println(themekit.YellowText("Does this look correct? (y/n)"))
 		text, _ := reader.ReadString('\n')
-		return text == "y"
+		return strings.TrimSpace(text) == "y"
 	}
 
 	saveFn := func() error {


### PR DESCRIPTION
Not all configurations will include the default "development"
environment. There is a good chance that this is on purpose, and
in that case, the user should just be required to specify which
environment they want to use.

Fixes #62 