### PR TITLE
Ensure correct base key for customer templates

### DIFF
--- a/file_watcher.go
+++ b/file_watcher.go
@@ -55,7 +55,6 @@ func NewFileWatcher(dir string, recur bool, filter EventFilter) (chan AssetEvent
 
 func fwLoadAsset(event fsnotify.Event) Asset {
 	root := filepath.Dir(event.Name)
-	fileParentDir := filepath.Base(root)
 	filename := filepath.Base(event.Name)
 
 	asset, err := LoadAsset(root, filename)
@@ -66,7 +65,7 @@ func fwLoadAsset(event fsnotify.Event) Asset {
 			asset = Asset{}
 		}
 	}
-	asset.Key = fmt.Sprintf("%s/%s", fileParentDir, filename)
+	asset.Key = extractAssetKey(event.Name)
 	return asset
 }
 

--- a/file_watcher_test.go
+++ b/file_watcher_test.go
@@ -17,10 +17,18 @@ func (s *FileWatcherSuite) TearDownTest() {
 }
 
 func (s *FileWatcherSuite) TestThatLoadAssetProperlyExtractsTheAssetKey() {
-	event := fsnotify.Event{Name: "fixtures/whatever.txt"}
-	asset := fwLoadAsset(event)
-	assert.Equal(s.T(), asset.Key, "fixtures/whatever.txt")
-	assert.Equal(s.T(), "whatever\n", asset.Value)
+	var tests = []struct {
+		input    fsnotify.Event
+		expected Asset
+	}{
+		{fsnotify.Event{Name: "fixtures/layout/theme.liquid"}, Asset{Key: "layout/theme.liquid", Value: "Liquid Theme\n"}},
+		{fsnotify.Event{Name: "fixtures/templates/customers/account.liquid"}, Asset{Key: "templates/customers/account.liquid", Value: "Account Page\n"}},
+	}
+	for _, test := range tests {
+		actual := fwLoadAsset(test.input)
+		assert.Equal(s.T(), test.expected.Key, actual.Key)
+		assert.Equal(s.T(), test.expected.Value, actual.Value)
+	}
 }
 
 func (s *FileWatcherSuite) TestDeterminingContentTypesOfFiles() {

--- a/fixtures/layout/theme.liquid
+++ b/fixtures/layout/theme.liquid
@@ -1,0 +1,1 @@
+Liquid Theme

--- a/fixtures/templates/customers/account.liquid
+++ b/fixtures/templates/customers/account.liquid
@@ -1,0 +1,1 @@
+Account Page


### PR DESCRIPTION
The base key for a customer template is more complicated
than regular templates (templates/customer) and these keys
were not being generated correctly. As a result, Shopify
would reject the upload.

This made it impossible to upload customer template changes
automatically

Fixes #60 