### PR TITLE
fix installer instructions to append path and not overwrite

### DIFF
--- a/install
+++ b/install
@@ -121,7 +121,7 @@ class Installer(object):
         print
         print "For example to add themekit to your .bashrc:"
         print
-        print '\techo "PATH=%s:$PATH" > ~/.bashrc' % self.installlocation
+        print '''\techo 'PATH="%s:$PATH"' >> ~/.bashrc''' % self.installlocation
         print '\tsource ~/.bashrc'
         print
         print 'To verify themekit is working simply type "theme -h"'


### PR DESCRIPTION
The instructions for appending to your path causes the entire profile to be overwritten. I wasn't paying attention myself and when I installed it, I took out my entire .zshrc file. Thankfully I have my dotfiles under version control. 

Fixed this to append the path and not overwrite it. I also set it to export the path and not expand the `PATH` variable inside the profile. I just personally find this makes reading my bash/zsh profiles a lot easier.

[![alt](https://screenshot.click/10-00-dj5k2-34zpn.jpg)](https://screenshot.click/10-00-dj5k2-34zpn.jpg)

@csaunders 