### PR TITLE
Adds Release script to enable automatic updating

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+AWS_KEY_ID=abracadabra
+AWS_SECRET_KEY=alakazam
+AWS_BUCKET_NAME=bucketbucket

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/
 nanoc/
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+ruby "2.2.2"
+
+gem 'dotenv'
+gem 'fog-aws'
+gem 'git'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,46 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    builder (3.2.2)
+    dotenv (2.0.2)
+    excon (0.45.4)
+    fog-aws (0.7.6)
+      fog-core (~> 1.27)
+      fog-json (~> 1.0)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-core (1.32.1)
+      builder
+      excon (~> 0.45)
+      formatador (~> 0.2)
+      mime-types
+      net-scp (~> 1.1)
+      net-ssh (>= 2.1.3)
+    fog-json (1.0.2)
+      fog-core (~> 1.0)
+      multi_json (~> 1.10)
+    fog-xml (0.1.2)
+      fog-core
+      nokogiri (~> 1.5, >= 1.5.11)
+    formatador (0.2.5)
+    git (1.2.9.1)
+    ipaddress (0.8.0)
+    mime-types (2.6.1)
+    mini_portile (0.6.2)
+    multi_json (1.11.2)
+    net-scp (1.2.1)
+      net-ssh (>= 2.6.5)
+    net-ssh (2.9.2)
+    nokogiri (1.6.6.2)
+      mini_portile (~> 0.6.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  dotenv
+  fog-aws
+  git
+
+BUNDLED WITH
+   1.10.5

--- a/Makefile
+++ b/Makefile
@@ -39,5 +39,7 @@ linux:
 zip:
 	./compress
 
-dist: windows mac linux zip
+upload_to_s3:
+	./release
 
+dist: clean windows mac linux zip upload_to_s3

--- a/release
+++ b/release
@@ -3,17 +3,16 @@ require 'fog'
 require 'dotenv'
 require 'json'
 require 'digest'
-require 'set'
 require 'git'
 
 Dotenv.load
 
-ALL_RELEASES = "releases/all.json"
-LATEST_RELEASE = "releases/latest.json"
-GIT_DIR = File.expand_path(__FILE__ + "/..")
-
 class FileManager
+  ALL_RELEASES = "releases/all.json"
+  LATEST_RELEASE = "releases/latest.json"
+
   attr_reader :bucket
+
   def initialize(bucket)
     @bucket = bucket
   end
@@ -28,16 +27,22 @@ class FileManager
   end
 
   def url(filename)
-    bucket.files.get(filename).public_url
+    get_file(filename).public_url
   end
 
   def fetch(filename, default: "")
-    return bucket.files.get(filename).body if bucket.files.head(filename)
-    return default
+    bucket.files.head(filename) ? get_file(filename).body : default
+  end
+
+  private
+  def get_file(name)
+    bucket.files.get(name)
   end
 end
 
 class Repository
+  GIT_DIR = File.expand_path(__FILE__ + "/..")
+
   def initialize
     @git = Git.open(GIT_DIR)
   end
@@ -48,25 +53,17 @@ class Repository
 end
 
 class Release
-  attr_reader :platform, :file, :version
+  attr_reader :platform, :file, :version, :full_name, :data
   attr_accessor :location
-  def initialize(version, platform, filename)
+
+  def initialize(version: nil, platform: nil, filename: nil)
     @platform = platform
     @version = version
-    @file = File.open(filename, 'rb')
-  end
-
-  def full_name
-    [version, platform, File.basename(file.path)].join('/')
-  end
-
-  def data
-    file.rewind
-    file.read
+    load_file(filename)
   end
 
   def hexdigest
-    Digest::MD5.hexdigest(data)
+    @hexdigest ||= Digest::MD5.hexdigest(data)
   end
 
   def as_hash
@@ -76,10 +73,19 @@ class Release
       "digest" => hexdigest
     }
   end
+
+  private
+  def load_file(filename)
+    file = File.open(filename, 'rb')
+    @full_name = [version, platform, File.basename(file.path)].join('/')
+    @data = file.read
+    file.close
+  end
 end
 
 class ReleaseGenerator
   attr_reader :version, :releases, :storage_manager
+
   DIST_DIR = File.expand_path(__FILE__ + "/../build/dist")
   BUILDS = %w(darwin-amd64 linux-386 linux-amd64 windows-386 windows-amd64)
 
@@ -98,6 +104,8 @@ class ReleaseGenerator
     end
   end
 
+  private
+
   def ensure_builds_have_been_created
     return if File.exist?(DIST_DIR)
     puts "Distribution build at #{DIST_DIR} has not been created. Run 'make dist' before attempting to create a new release"
@@ -105,7 +113,7 @@ class ReleaseGenerator
   end
 
   def ensure_release_is_necessary
-    feed = JSON.parse(storage_manager.fetch(ALL_RELEASES, default:  '[]'))
+    feed = JSON.parse(storage_manager.fetch(FileManager::ALL_RELEASES, default:  [].to_json))
     if feed.find { |r| r['version'] == version }
       puts "v#{version} has already been deployed. If this was intended to be a new release, ensure version.go has been updated and add an appropriate tag to git"
       exit(1)
@@ -116,13 +124,14 @@ class ReleaseGenerator
     BUILDS.map do |platform|
       build_location = File.expand_path(DIST_DIR + "/#{platform}")
       binary = Dir.entries(build_location).find { |name| name =~ /theme/ }
-      Release.new(version, platform, [build_location, binary].join('/'))
+      Release.new(version: version, platform: platform, filename: [build_location, binary].join('/'))
     end
   end
 end
 
 class FeedGenerator
   attr_reader :version, :releases, :storage_manager
+
   def initialize(version, releases, storage_manager)
     @version = version
     @releases = releases
@@ -130,20 +139,20 @@ class FeedGenerator
   end
 
   def upload!
-    storage_manager.upload!(LATEST_RELEASE, latest_feed)
-    storage_manager.upload!(ALL_RELEASES, entire_feed)
+    storage_manager.upload!(FileManager::LATEST_RELEASE, latest_feed)
+    storage_manager.upload!(FileManager::ALL_RELEASES, entire_feed)
   end
+
+  private
 
   def latest_feed
     as_hash.to_json
   end
 
   def entire_feed
-    full_feed = JSON.parse(storage_manager.fetch(ALL_RELEASES, default: "[]"))
+    full_feed = JSON.parse(storage_manager.fetch(FileManager::ALL_RELEASES, default: [].to_json))
     full_feed << as_hash
-    full_feed.each_with_object(Set.new) do |release, memo|
-      memo << release
-    end.to_a.to_json
+    full_feed.uniq.to_json
   end
 
   def as_hash

--- a/release
+++ b/release
@@ -31,12 +31,18 @@ class FileManager
   end
 
   def fetch(filename, default: "")
-    bucket.files.head(filename) ? get_file(filename).body : default
+    exists?(filename) ? get_file(filename).body : default
   end
 
   private
   def get_file(name)
     bucket.files.get(name)
+  end
+
+  def exists?(name)
+    bucket.files.head(name)
+  rescue => e
+    false
   end
 end
 
@@ -45,10 +51,24 @@ class Repository
 
   def initialize
     @git = Git.open(GIT_DIR)
+    ensure_head_is_at_latest_version
   end
 
   def latest_version
-    @git.tags.last.name
+    latest_tag.name
+  end
+
+  private
+  def latest_tag
+    @git.tags.last
+  end
+
+  def ensure_head_is_at_latest_version
+    if @git.object('HEAD').sha != latest_tag.sha
+      puts "Your current HEAD does not match tag #{latest_version}."
+      puts "Verify you are at the right commit or create a new tag."
+      exit(1)
+    end
   end
 end
 
@@ -96,9 +116,10 @@ class ReleaseGenerator
     @storage_manager = storage_manager
   end
 
-  def upload!
+  def upload!(logger: nil)
     ensure_release_is_necessary
     releases.each do |release|
+      logger.puts "  - Uploading #{release.full_name}" if logger
       storage_manager.upload!(release.full_name, release.data)
       release.location = storage_manager.url(release.full_name)
     end
@@ -138,7 +159,8 @@ class FeedGenerator
     @storage_manager = storage_manager
   end
 
-  def upload!
+  def upload!(logger: nil)
+    logger.puts "Updating feeds" if logger
     storage_manager.upload!(FileManager::LATEST_RELEASE, latest_feed)
     storage_manager.upload!(FileManager::ALL_RELEASES, entire_feed)
   end
@@ -163,22 +185,23 @@ class FeedGenerator
   end
 end
 
+puts "Establishing Connection to Amazon S3"
 connection = Fog::Storage.new(
   provider: 'AWS',
   aws_access_key_id: ENV['AWS_KEY_ID'],
   aws_secret_access_key: ENV['AWS_SECRET_KEY']
 )
 
-bucket = connection.directories.create(
-  key: ENV['AWS_BUCKET_NAME'],
-  public: true
-)
+bucket = Fog::Storage::AWS::Directory.new(key: ENV['AWS_BUCKET_NAME'], service: connection)
 manager = FileManager.new(bucket)
+puts "Determining latest release"
 repo = Repository.new
 version = repo.latest_version
 
+puts "Uploading releases for #{version} to S3"
+
 release_generator = ReleaseGenerator.new(version, manager)
-release_generator.upload!
+release_generator.upload!(logger: STDOUT)
 
 feed_generator = FeedGenerator.new(version, release_generator.releases, manager)
-feed_generator.upload!
+feed_generator.upload!(logger: STDOUT)

--- a/release
+++ b/release
@@ -1,0 +1,175 @@
+#!/usr/bin/env ruby
+require 'fog'
+require 'dotenv'
+require 'json'
+require 'digest'
+require 'set'
+require 'git'
+
+Dotenv.load
+
+ALL_RELEASES = "releases/all.json"
+LATEST_RELEASE = "releases/latest.json"
+GIT_DIR = File.expand_path(__FILE__ + "/..")
+
+class FileManager
+  attr_reader :bucket
+  def initialize(bucket)
+    @bucket = bucket
+  end
+
+  def upload!(filename, content)
+    file = bucket.files.new(
+      key: filename,
+      body: content,
+      public: true
+    )
+    file.save
+  end
+
+  def url(filename)
+    bucket.files.get(filename).public_url
+  end
+
+  def fetch(filename, default: "")
+    return bucket.files.get(filename).body if bucket.files.head(filename)
+    return default
+  end
+end
+
+class Repository
+  def initialize
+    @git = Git.open(GIT_DIR)
+  end
+
+  def latest_version
+    @git.tags.last.name
+  end
+end
+
+class Release
+  attr_reader :platform, :file, :version
+  attr_accessor :location
+  def initialize(version, platform, filename)
+    @platform = platform
+    @version = version
+    @file = File.open(filename, 'rb')
+  end
+
+  def full_name
+    [version, platform, File.basename(file.path)].join('/')
+  end
+
+  def data
+    file.rewind
+    file.read
+  end
+
+  def hexdigest
+    Digest::MD5.hexdigest(data)
+  end
+
+  def as_hash
+    {
+      "name" => platform,
+      "url" => location,
+      "digest" => hexdigest
+    }
+  end
+end
+
+class ReleaseGenerator
+  attr_reader :version, :releases, :storage_manager
+  DIST_DIR = File.expand_path(__FILE__ + "/../build/dist")
+  BUILDS = %w(darwin-amd64 linux-386 linux-amd64 windows-386 windows-amd64)
+
+  def initialize(version, storage_manager)
+    ensure_builds_have_been_created
+    @version = version
+    @releases = prepare_releases
+    @storage_manager = storage_manager
+  end
+
+  def upload!
+    ensure_release_is_necessary
+    releases.each do |release|
+      storage_manager.upload!(release.full_name, release.data)
+      release.location = storage_manager.url(release.full_name)
+    end
+  end
+
+  def ensure_builds_have_been_created
+    return if File.exist?(DIST_DIR)
+    puts "Distribution build at #{DIST_DIR} has not been created. Run 'make dist' before attempting to create a new release"
+    exit(1)
+  end
+
+  def ensure_release_is_necessary
+    feed = JSON.parse(storage_manager.fetch(ALL_RELEASES, default:  '[]'))
+    if feed.find { |r| r['version'] == version }
+      puts "v#{version} has already been deployed. If this was intended to be a new release, ensure version.go has been updated and add an appropriate tag to git"
+      exit(1)
+    end
+  end
+
+  def prepare_releases
+    BUILDS.map do |platform|
+      build_location = File.expand_path(DIST_DIR + "/#{platform}")
+      binary = Dir.entries(build_location).find { |name| name =~ /theme/ }
+      Release.new(version, platform, [build_location, binary].join('/'))
+    end
+  end
+end
+
+class FeedGenerator
+  attr_reader :version, :releases, :storage_manager
+  def initialize(version, releases, storage_manager)
+    @version = version
+    @releases = releases
+    @storage_manager = storage_manager
+  end
+
+  def upload!
+    storage_manager.upload!(LATEST_RELEASE, latest_feed)
+    storage_manager.upload!(ALL_RELEASES, entire_feed)
+  end
+
+  def latest_feed
+    as_hash.to_json
+  end
+
+  def entire_feed
+    full_feed = JSON.parse(storage_manager.fetch(ALL_RELEASES, default: "[]"))
+    full_feed << as_hash
+    full_feed.each_with_object(Set.new) do |release, memo|
+      memo << release
+    end.to_a.to_json
+  end
+
+  def as_hash
+    {
+      "version" => version,
+      "platforms" => releases.map(&:as_hash)
+    }
+  end
+end
+
+connection = Fog::Storage.new(
+  provider: 'AWS',
+  aws_access_key_id: ENV['AWS_KEY_ID'],
+  aws_secret_access_key: ENV['AWS_SECRET_KEY']
+)
+
+bucket = connection.directories.create(
+  key: ENV['AWS_BUCKET_NAME'],
+  public: true
+)
+manager = FileManager.new(bucket)
+repo = Repository.new
+version = repo.latest_version
+
+release_generator = ReleaseGenerator.new(version, manager)
+release_generator.upload!
+
+feed_generator = FeedGenerator.new(version, release_generator.releases, manager)
+feed_generator.upload!


### PR DESCRIPTION
In order to perform automatic updates we need to know
where the new binary is going to be. While it is possible
to include that in the binary itself, that's fragile.

This is a basic script that builds provides two feeds
along with directories containing the new binary for
each platform.

Clients can either pull down changes from latest.json
or if the version difference is too large apply changes
one at a time (more important if we move over to binary
delta patches).

Right now we'll just upload new uncompressed binaries to
S3 each time and add a new record to the all.json feed.

There is also some guard code in the release script to
ensure that we don't attempt to create an update if
the build hasn't been run or if we've already uploaded
that version.

---------------------

I know that this doesn't have any tests, please forgive me. I don't know if it's _really_ worth testing or not. There is a fair amount of functionality in there though, so maybe I should.

Please review @nickhoffman @jamesmacaulay 

This is one step towards resolving https://github.com/Shopify/themekit/issues/65