### PR TITLE
Ignores files that are considered to be compiled

### DIFF
--- a/asset.go
+++ b/asset.go
@@ -24,6 +24,21 @@ func (a Asset) IsValid() bool {
 	return len(a.Key) > 0 && (len(a.Value) > 0 || len(a.Attachment) > 0)
 }
 
+// Implementing sort.Interface
+type ByAsset []Asset
+
+func (assets ByAsset) Len() int {
+	return len(assets)
+}
+
+func (assets ByAsset) Swap(i, j int) {
+	assets[i], assets[j] = assets[j], assets[i]
+}
+
+func (assets ByAsset) Less(i, j int) bool {
+	return assets[i].Key < assets[j].Key
+}
+
 func LoadAsset(root, filename string) (asset Asset, err error) {
 	path := toSlash(fmt.Sprintf("%s/%s", root, filename))
 	file, err := os.Open(path)

--- a/asset_test.go
+++ b/asset_test.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 )
@@ -137,4 +138,23 @@ func (s *LoadAssetSuite) noteAllocatedFile(name string) {
 func TestLoadAssetSuite(t *testing.T) {
 	LoadAsset("foo", "bar")
 	suite.Run(t, new(LoadAssetSuite))
+}
+
+func TestSortListOfAssets(t *testing.T) {
+	input := []Asset{
+		Asset{Key: "assets/ajaxify.js.liquid"},
+		Asset{Key: "assets/ajaxify.js"},
+		Asset{Key: "assets/ajaxify.css"},
+		Asset{Key: "assets/ajaxify.css.liquid"},
+		Asset{Key: "layouts/customers.liquid"},
+	}
+	expected := []Asset{
+		Asset{Key: "assets/ajaxify.css"},
+		Asset{Key: "assets/ajaxify.css.liquid"},
+		Asset{Key: "assets/ajaxify.js"},
+		Asset{Key: "assets/ajaxify.js.liquid"},
+		Asset{Key: "layouts/customers.liquid"},
+	}
+	sort.Sort(ByAsset(input))
+	assert.Equal(t, expected, input)
 }

--- a/fixtures/assets_response_from_shopify.json
+++ b/fixtures/assets_response_from_shopify.json
@@ -1,10 +1,10 @@
 {
   "assets": [
     {
-      "key": "assets\/ajaxify.js"
+      "key": "assets\/ajaxify.js.liquid"
     },
     {
-      "key": "assets\/ajaxify.js.liquid"
+      "key": "assets\/ajaxify.js"
     },
     {
       "key": "assets\/ajaxify.scss"

--- a/fixtures/assets_response_from_shopify.json
+++ b/fixtures/assets_response_from_shopify.json
@@ -1,0 +1,241 @@
+{
+  "assets": [
+    {
+      "key": "assets\/ajaxify.js"
+    },
+    {
+      "key": "assets\/ajaxify.js.liquid"
+    },
+    {
+      "key": "assets\/ajaxify.scss"
+    },
+    {
+      "key": "assets\/ajaxify.scss.liquid"
+    },
+    {
+      "key": "assets\/checkout.css"
+    },
+    {
+      "key": "assets\/checkout.css.liquid"
+    },
+    {
+      "key": "assets\/collection-view-grid.svg"
+    },
+    {
+      "key": "assets\/collection-view-list.svg"
+    },
+    {
+      "key": "assets\/exercise-2.24.jpg"
+    },
+    {
+      "key": "assets\/gift-card-line-icon.svg"
+    },
+    {
+      "key": "assets\/gift-card-line-icon.svg.liquid"
+    },
+    {
+      "key": "assets\/gift-card.scss"
+    },
+    {
+      "key": "assets\/gift-card.scss.liquid"
+    },
+    {
+      "key": "assets\/handlebars.min.js"
+    },
+    {
+      "key": "assets\/icons.eot"
+    },
+    {
+      "key": "assets\/icons.svg"
+    },
+    {
+      "key": "assets\/icons.ttf"
+    },
+    {
+      "key": "assets\/icons.woff"
+    },
+    {
+      "key": "assets\/modernizr.min.js"
+    },
+    {
+      "key": "assets\/owl.carousel.min.css"
+    },
+    {
+      "key": "assets\/owl.carousel.min.js"
+    },
+    {
+      "key": "assets\/respond-proxy.html"
+    },
+    {
+      "key": "assets\/respond.min.js"
+    },
+    {
+      "key": "assets\/shop.js"
+    },
+    {
+      "key": "assets\/shop.js.liquid"
+    },
+    {
+      "key": "assets\/slide_1.jpg"
+    },
+    {
+      "key": "assets\/timber.scss"
+    },
+    {
+      "key": "assets\/timber.scss.liquid"
+    },
+    {
+      "key": "config\/settings.html"
+    },
+    {
+      "key": "config\/settings_data.json"
+    },
+    {
+      "key": "config\/settings_schema.json"
+    },
+    {
+      "key": "layout\/theme.liquid"
+    },
+    {
+      "key": "locales\/de.json"
+    },
+    {
+      "key": "locales\/en.default.json"
+    },
+    {
+      "key": "locales\/es.json"
+    },
+    {
+      "key": "locales\/fr.json"
+    },
+    {
+      "key": "locales\/pt-BR.json"
+    },
+    {
+      "key": "locales\/pt-PT.json"
+    },
+    {
+      "key": "snippets\/ajax-cart-template.liquid"
+    },
+    {
+      "key": "snippets\/blank-single-product.liquid"
+    },
+    {
+      "key": "snippets\/blog-sorting.liquid"
+    },
+    {
+      "key": "snippets\/breadcrumb.liquid"
+    },
+    {
+      "key": "snippets\/collection-grid-item.liquid"
+    },
+    {
+      "key": "snippets\/collection-sorting.liquid"
+    },
+    {
+      "key": "snippets\/collection-tags.liquid"
+    },
+    {
+      "key": "snippets\/comment.liquid"
+    },
+    {
+      "key": "snippets\/echo-product-handle.liquid"
+    },
+    {
+      "key": "snippets\/featured-collection.liquid"
+    },
+    {
+      "key": "snippets\/featured-collections.liquid"
+    },
+    {
+      "key": "snippets\/featured-product.liquid"
+    },
+    {
+      "key": "snippets\/footer.liquid"
+    },
+    {
+      "key": "snippets\/home-content.liquid"
+    },
+    {
+      "key": "snippets\/newsletter-form.liquid"
+    },
+    {
+      "key": "snippets\/oldIE-js.liquid"
+    },
+    {
+      "key": "snippets\/pagination-custom.liquid"
+    },
+    {
+      "key": "snippets\/price.liquid"
+    },
+    {
+      "key": "snippets\/product-grid-item.liquid"
+    },
+    {
+      "key": "snippets\/product-list-item.liquid"
+    },
+    {
+      "key": "snippets\/respond.liquid"
+    },
+    {
+      "key": "snippets\/search-result-grid.liquid"
+    },
+    {
+      "key": "snippets\/search-result.liquid"
+    },
+    {
+      "key": "snippets\/site-nav.liquid"
+    },
+    {
+      "key": "snippets\/slider.liquid"
+    },
+    {
+      "key": "snippets\/social-buttons.liquid"
+    },
+    {
+      "key": "snippets\/tags-article.liquid"
+    },
+    {
+      "key": "snippets\/twitter-card.liquid"
+    },
+    {
+      "key": "templates\/article.liquid"
+    },
+    {
+      "key": "templates\/blog.liquid"
+    },
+    {
+      "key": "templates\/cart.liquid"
+    },
+    {
+      "key": "templates\/collection.liquid"
+    },
+    {
+      "key": "templates\/customers\/account.liquid"
+    },
+    {
+      "key": "templates\/customers\/activate_account.liquid"
+    },
+    {
+      "key": "templates\/customers\/login.liquid"
+    },
+    {
+      "key": "templates\/customers\/order.liquid"
+    },
+    {
+      "key": "templates\/customers\/reset_password.liquid"
+    },
+    {
+      "key": "templates\/gift_card.liquid"
+    },
+    {
+      "key": "templates\/index.liquid"
+    },
+    {
+      "key": "templates\/page.liquid"
+    },
+    {
+      "key": "templates\/product.liquid"
+    }
+  ]
+}

--- a/fixtures/expected_asset_list_output.json
+++ b/fixtures/expected_asset_list_output.json
@@ -1,0 +1,220 @@
+{
+  "assets": [
+    {
+      "key": "assets\/ajaxify.js.liquid"
+    },
+    {
+      "key": "assets\/ajaxify.scss.liquid"
+    },
+    {
+      "key": "assets\/checkout.css.liquid"
+    },
+    {
+      "key": "assets\/collection-view-grid.svg"
+    },
+    {
+      "key": "assets\/collection-view-list.svg"
+    },
+    {
+      "key": "assets\/exercise-2.24.jpg"
+    },
+    {
+      "key": "assets\/gift-card-line-icon.svg.liquid"
+    },
+    {
+      "key": "assets\/gift-card.scss.liquid"
+    },
+    {
+      "key": "assets\/handlebars.min.js"
+    },
+    {
+      "key": "assets\/icons.eot"
+    },
+    {
+      "key": "assets\/icons.svg"
+    },
+    {
+      "key": "assets\/icons.ttf"
+    },
+    {
+      "key": "assets\/icons.woff"
+    },
+    {
+      "key": "assets\/modernizr.min.js"
+    },
+    {
+      "key": "assets\/owl.carousel.min.css"
+    },
+    {
+      "key": "assets\/owl.carousel.min.js"
+    },
+    {
+      "key": "assets\/respond-proxy.html"
+    },
+    {
+      "key": "assets\/respond.min.js"
+    },
+    {
+      "key": "assets\/shop.js.liquid"
+    },
+    {
+      "key": "assets\/slide_1.jpg"
+    },
+    {
+      "key": "assets\/timber.scss.liquid"
+    },
+    {
+      "key": "config\/settings.html"
+    },
+    {
+      "key": "config\/settings_data.json"
+    },
+    {
+      "key": "config\/settings_schema.json"
+    },
+    {
+      "key": "layout\/theme.liquid"
+    },
+    {
+      "key": "locales\/de.json"
+    },
+    {
+      "key": "locales\/en.default.json"
+    },
+    {
+      "key": "locales\/es.json"
+    },
+    {
+      "key": "locales\/fr.json"
+    },
+    {
+      "key": "locales\/pt-BR.json"
+    },
+    {
+      "key": "locales\/pt-PT.json"
+    },
+    {
+      "key": "snippets\/ajax-cart-template.liquid"
+    },
+    {
+      "key": "snippets\/blank-single-product.liquid"
+    },
+    {
+      "key": "snippets\/blog-sorting.liquid"
+    },
+    {
+      "key": "snippets\/breadcrumb.liquid"
+    },
+    {
+      "key": "snippets\/collection-grid-item.liquid"
+    },
+    {
+      "key": "snippets\/collection-sorting.liquid"
+    },
+    {
+      "key": "snippets\/collection-tags.liquid"
+    },
+    {
+      "key": "snippets\/comment.liquid"
+    },
+    {
+      "key": "snippets\/echo-product-handle.liquid"
+    },
+    {
+      "key": "snippets\/featured-collection.liquid"
+    },
+    {
+      "key": "snippets\/featured-collections.liquid"
+    },
+    {
+      "key": "snippets\/featured-product.liquid"
+    },
+    {
+      "key": "snippets\/footer.liquid"
+    },
+    {
+      "key": "snippets\/home-content.liquid"
+    },
+    {
+      "key": "snippets\/newsletter-form.liquid"
+    },
+    {
+      "key": "snippets\/oldIE-js.liquid"
+    },
+    {
+      "key": "snippets\/pagination-custom.liquid"
+    },
+    {
+      "key": "snippets\/price.liquid"
+    },
+    {
+      "key": "snippets\/product-grid-item.liquid"
+    },
+    {
+      "key": "snippets\/product-list-item.liquid"
+    },
+    {
+      "key": "snippets\/respond.liquid"
+    },
+    {
+      "key": "snippets\/search-result-grid.liquid"
+    },
+    {
+      "key": "snippets\/search-result.liquid"
+    },
+    {
+      "key": "snippets\/site-nav.liquid"
+    },
+    {
+      "key": "snippets\/slider.liquid"
+    },
+    {
+      "key": "snippets\/social-buttons.liquid"
+    },
+    {
+      "key": "snippets\/tags-article.liquid"
+    },
+    {
+      "key": "snippets\/twitter-card.liquid"
+    },
+    {
+      "key": "templates\/article.liquid"
+    },
+    {
+      "key": "templates\/blog.liquid"
+    },
+    {
+      "key": "templates\/cart.liquid"
+    },
+    {
+      "key": "templates\/collection.liquid"
+    },
+    {
+      "key": "templates\/customers\/account.liquid"
+    },
+    {
+      "key": "templates\/customers\/activate_account.liquid"
+    },
+    {
+      "key": "templates\/customers\/login.liquid"
+    },
+    {
+      "key": "templates\/customers\/order.liquid"
+    },
+    {
+      "key": "templates\/customers\/reset_password.liquid"
+    },
+    {
+      "key": "templates\/gift_card.liquid"
+    },
+    {
+      "key": "templates\/index.liquid"
+    },
+    {
+      "key": "templates\/page.liquid"
+    },
+    {
+      "key": "templates\/product.liquid"
+    }
+  ]
+}

--- a/theme_client.go
+++ b/theme_client.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -105,6 +106,7 @@ func (t ThemeClient) AssetList() (results chan Asset, errs chan error) {
 			return
 		}
 
+		sort.Sort(ByAsset(assets["assets"]))
 		sanitizedAssets := ignoreCompiledAssets(assets["assets"])
 
 		for _, asset := range sanitizedAssets {

--- a/utils.go
+++ b/utils.go
@@ -19,6 +19,10 @@ var BlueText = color.New(color.FgBlue).SprintFunc()
 var GreenText = color.New(color.FgGreen).SprintFunc()
 
 func TestFixture(name string) string {
+	return string(RawTestFixture(name))
+}
+
+func RawTestFixture(name string) []byte {
 	path := fmt.Sprintf("fixtures/%s.json", name)
 	file, err := os.Open(path)
 	defer file.Close()
@@ -29,7 +33,7 @@ func TestFixture(name string) string {
 	if err != nil {
 		log.Fatal(err)
 	}
-	return string(bytes)
+	return bytes
 }
 
 func BinaryTestData() []byte {


### PR DESCRIPTION
This is a pretty rough estimation as to which files are
compiled, but most of them typically follow a similar scheme
like "filename.js.liquid" and so on.

There is a chance this might cause some other kinds of bugs though,
so perhaps this isn't the right approach. Another alternative is
to simply detect those files and add them to the ignore section
of the environments configuration.

Fixes #41

Please provide feedback, review, etc. @chrisbutcher