### PR TITLE
Simplifies and fixes replacing a themes assets

### DIFF
--- a/theme_client_test.go
+++ b/theme_client_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"sort"
 	"testing"
 )
@@ -90,6 +91,15 @@ func TestRetrievingAnAssetList(t *testing.T) {
 	client := NewThemeClient(conf(ts))
 	assets, _ := client.AssetList()
 	assert.Equal(t, 2, count(assets))
+}
+
+func TestRetrievingLocalAssets(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	client := NewThemeClient(conf(ts))
+
+	dir, _ := os.Getwd()
+	assets := client.LocalAssets(fmt.Sprintf("%s/fixtures/templates", dir))
+	assert.Equal(t, 1, len(assets))
 }
 
 func TestRetrievingAnAssetListThatIncludesCompiledAssets(t *testing.T) {


### PR DESCRIPTION
Theme replace didn't actually do it's job correctly. It would just replace existing assets on Shopify and get sad if they did not exist. Instead we actually go out and do a correct replacement buy queueing all the remote assets to be destroyed, then replacing any duplicates with update events.

The advantage is somewhat twofold:

- Reduces overall API calls since we only delete assets that don't need to be there
- Is correct

Please review @chrisbutcher 

Fixes https://github.com/Shopify/themekit/issues/64

/cc @stevebosworth 