### PR TITLE
Fixes File Descriptor exhaustion

### DIFF
--- a/asset.go
+++ b/asset.go
@@ -46,6 +46,7 @@ func LoadAsset(root, filename string) (asset Asset, err error) {
 	if err != nil {
 		return
 	}
+	defer file.Close()
 
 	if info.IsDir() {
 		err = errors.New("File is a directory")


### PR DESCRIPTION
Files were not being closed after they were used.
Typically this didn't really cause any issues, but sometimes
when working on large projects or when running the application
for an extended period of time the app would crash with a
really undescriptive error message.

The underlying issue was because we were keeping files open.

By defering Close on the file we ensure that we don't exhaust our
File Descriptor limits.

Fixes https://github.com/Shopify/themekit/issues/63

Please review @chrisbutcher 

/cc @stevebosworth 