### PR TITLE
Ignore CHMOD events

### DIFF
--- a/file_watcher.go
+++ b/file_watcher.go
@@ -73,7 +73,7 @@ func HandleEvent(event fsnotify.Event) FsAssetEvent {
 	var eventType EventType
 	asset := fwLoadAsset(event)
 	switch event.Op {
-	case fsnotify.Create, fsnotify.Chmod:
+	case fsnotify.Create:
 		eventType = Update
 	case fsnotify.Remove:
 		eventType = Remove
@@ -110,6 +110,10 @@ func convertFsEvents(events chan fsnotify.Event, filter EventFilter) chan AssetE
 		duplicateEventTimeout := map[string]int64{}
 		for {
 			event := <-events
+
+			if event.Op == fsnotify.Chmod {
+				continue
+			}
 
 			if !filter.MatchesFilter(event.Name) {
 				fsevent := HandleEvent(event)


### PR DESCRIPTION
Git triggers a lot of these kinds of events that
actually aren't relevant and result in generating
unnecessary events that we don't actually care about

Fixes #56