### PR TITLE
Removes --command="download" from theme --help

### DIFF
--- a/cmd/theme/main.go
+++ b/cmd/theme/main.go
@@ -287,17 +287,14 @@ func loadEnvironments(directory string) (themekit.Environments, error) {
 }
 
 func SetupAndParseArgs(args []string) (command string, rest []string) {
-
 	set := makeFlagSet("")
-	set.StringVar(&command, "command", "download", CommandDescription(commandDefault))
+	set.Usage = func() {
+		fmt.Println(CommandDescription(commandDefault))
+	}
 	set.Parse(args)
 
-	if len(args) != set.NArg() {
-		rest = args[len(args)-set.NArg():]
-	} else if len(args) > 0 {
-		command = args[0]
-		rest = args[1:]
-	}
+	command = args[0]
+	rest = args[1:]
 	return
 }
 


### PR DESCRIPTION
There were some extra flags showing up that didn't really
make any sense for the user. This fixes that such that
the flag doesn't show up (because it should never really
be used in the first place)

Fixes https://github.com/Shopify/themekit/issues/88