### PR TITLE
make python install align with manual instructions

### DIFF
--- a/install
+++ b/install
@@ -64,7 +64,7 @@ class Releases(object):
         return HTTPSClient.get(Releases.FEED_HOST, Releases.FEED_PATH)
 
 class Installer(object):
-    def __init__(self, ziplocation, installlocation="~/.themekit"):
+    def __init__(self, ziplocation, installlocation="~/Applications/bin"):
         self.host, self.path, self.root = ziplocation
         self.root = self.root.replace('.zip', '')
         self.zipfile = os.path.basename(self.path)


### PR DESCRIPTION
The manual OSX install instructions tell users to create a `/bin` folder inside `~/Applications` to install the theme executable, but the python installed adds the executable to `~/.themekit`. They should probably be the same path regardless of how its installed. This PR just edits the install path to match 

Semi-related to this issue https://github.com/Shopify/themekit/issues/107

@csaunders 