### PR TITLE
fix install typo for creating new application path

### DIFF
--- a/install/index.html
+++ b/install/index.html
@@ -40,7 +40,7 @@
 
 
     <div class="container">
-      
+
 <h1 id="automatic-installation">Automatic Installation</h1>
 
 <p>If you are on <strong>Mac or Linux</strong> you can use the following installation script to automatically download and install
@@ -71,7 +71,7 @@ Theme Kit for you. You will need to make a small change to your shell initializa
   <li>
     <p>Create a directory called <code>Applications/bin</code>. You can enter the command in a terminal window to create it:</p>
 
-    <pre><code>mkdir -p ~/Applications</code></pre>
+    <pre><code>mkdir -p ~/Applications/bin</code></pre>
   </li>
   <li>
     <p>Open the <code>~Applications/bin</code> directory and move the downloaded <code>theme</code> program into it. On Mac OS you can enter the following command to open both teh the <code>bin</code> and <code>Download</code> directories.</p>
@@ -91,7 +91,7 @@ Theme Kit for you. You will need to make a small change to your shell initializa
 <li class="nostyle">
   <ul>
     <li class="nostyle">
-      <pre><code class="language-bash"><span class="nb">export </span><span class="nv">PATH</span><span class="o">=</span><span class="nv">$PATH</span>:~/Applications/bin</code></pre>
+      <pre><code class="language-bash"><span class="nb">export </span><span class="nv">PATH</span><span class="o">=</span>~/Applications/bin:<span class="nv">$PATH</span></code></pre>
     </li>
   </ul>
 </li>


### PR DESCRIPTION
https://github.com/Shopify/themekit/issues/107

When following the manual install instructions there are two typos

a) The command to create `~/Applications/bin` is not complete and just tries to make `~/Applications` when the following commands depend on `~/Applications/bin`

b) When extending the PATH, the export order is backwards which causes the themekit executable to be the very last thing checked, which means older installs of the theme Gem will superseed it on the path. 

This PR should fix both 

@csaunders 