### PR TITLE
Fix file watch issues in Windows

### DIFF
--- a/file_watcher.go
+++ b/file_watcher.go
@@ -95,6 +95,8 @@ func Encode64(data []byte) string {
 }
 
 func extractAssetKey(filename string) string {
+	filename = filepath.ToSlash(filename)
+	
 	for _, dir := range assetLocations {
 		split := strings.SplitAfterN(filename, dir, 2)
 		if len(split) > 1 {


### PR DESCRIPTION
Windows uses "\" as a path separator, while Shopify asset paths use "/". This converts the file paths to use "/" so the correct asset path can be generated. Fix for issue at #106 