### PR TITLE
Added OS and architecture to user-agent string

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"runtime"
 )
 
 type Configuration struct {
@@ -82,7 +83,7 @@ func (conf Configuration) AddHeaders(req *http.Request) {
 	req.Header.Add("X-Shopify-Access-Token", conf.AccessToken)
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Accept", "application/json")
-	req.Header.Add("User-Agent", "go/themekit")
+	req.Header.Add("User-Agent", fmt.Sprintf("go/themekit (%s; %s)", runtime.GOOS, runtime.GOARCH))
 }
 
 func (c Configuration) String() string {

--- a/configuration_test.go
+++ b/configuration_test.go
@@ -3,6 +3,9 @@ package themekit
 import (
 	"bytes"
 	"github.com/stretchr/testify/assert"
+	"net/http"
+	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -52,6 +55,17 @@ refill_rate: 4
 `
 	assert.Nil(t, err, "An error should not have been raised")
 	assert.Equal(t, expectedConfiguration, string(buffer.Bytes()))
+}
+
+func TestAddHeadersAddsPlatformAndArchitecture(t *testing.T) {
+	req, _ := http.NewRequest("GET", "/foo/bar", nil)
+
+	config := Configuration{Domain: "hello.myshopify.com", AccessToken: "secret", BucketSize: 10, RefillRate: 4}
+	config.AddHeaders(req)
+
+	userAgent := req.Header.Get("User-Agent")
+	assert.True(t, strings.Contains(userAgent, runtime.GOOS))
+	assert.True(t, strings.Contains(userAgent, runtime.GOARCH))
 }
 
 const (


### PR DESCRIPTION
Fixes #101. Not sure about the format of the string but at least it
contains arch and os now.

@csaunders 