### PR TITLE
Automatically setting file limits on startup for unix like platforms

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby "2.2.2"
+ruby "2.2.3"
 
 gem 'dotenv'
 gem 'fog-aws'

--- a/Makefile
+++ b/Makefile
@@ -4,14 +4,14 @@ all:
 	for subproject in $(SUBPROJECTS); \
 	do \
 		mkdir -p build/development; \
-	  godep go build -o build/development/$${subproject} cmd/$${subproject}/*.go; \
+	  godep go build -o build/development/$${subproject} github.com/Shopify/themekit/cmd/$${subproject}; \
   done
 
 build:
 	for subproject in $(SUBPROJECTS); \
 	do \
 	  mkdir -p build/dist/${GOOS}-${GOARCH}; \
-		godep go build -o build/dist/${GOOS}-${GOARCH}/$${subproject}${EXT} cmd/$${subproject}/*.go; \
+		godep go build -o build/dist/${GOOS}-${GOARCH}/$${subproject}${EXT} github.com/Shopify/themekit/cmd/$${subproject}; \
 	done
 
 test:

--- a/cmd/theme/setup_darwin.go
+++ b/cmd/theme/setup_darwin.go
@@ -1,17 +1,22 @@
-// +build !windows
+// +build darwin,amd64
+
 package main
 
 import (
 	"fmt"
+	"math"
 	"syscall"
 )
 
+const MinFileDescriptors float64 = 2048
+
+// MacOSX sets a very low default file descriptor limit per process. This function sets file descriptor limits to a more sane value.
 func init() {
 	var rLimit syscall.Rlimit
 	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit); err != nil {
 		fmt.Printf("Could not read max file limit: %s\n", err)
 	}
-	rLimit.Cur = 2048
+	rLimit.Cur = uint64(math.Max(MinFileDescriptors, float64(rLimit.Cur)))
 	if err := syscall.Setrlimit(syscall.RLIMIT_NOFILE, &rLimit); err != nil {
 		fmt.Printf("[warning] %s\n", err)
 		fmt.Printf("[warning] could not set file descriptor limits. Themekit will work, but you might encounter issues if your project holds many files. You can set the limits manually using ulimit -n 2048.\n")

--- a/cmd/theme/unix_setup.go
+++ b/cmd/theme/unix_setup.go
@@ -1,0 +1,20 @@
+// +build !windows
+package main
+
+import (
+	"fmt"
+	"syscall"
+)
+
+func init() {
+	var rLimit syscall.Rlimit
+	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit); err != nil {
+		fmt.Printf("Could not read max file limit: %s\n", err)
+	}
+	rLimit.Cur = 2048
+	if err := syscall.Setrlimit(syscall.RLIMIT_NOFILE, &rLimit); err != nil {
+		fmt.Printf("[warning] %s\n", err)
+		fmt.Printf("[warning] could not set file descriptor limits. Themekit will work, but you might encounter issues if your project holds many files. You can set the limits manually using ulimit -n 2048.\n")
+	}
+
+}


### PR DESCRIPTION
Automatically set file limits on startup for unix (non-windows) systems. See #116. 

@csaunders do we have any windows people here that could do a quick smoke test for us? 