### PR TITLE
LoadConfiguration now returns errors when the config is missing values

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -28,15 +28,15 @@ const (
 	DefaultConcurrency int = 2
 )
 
-func LoadConfiguration(contents []byte) (conf Configuration, err error) {
-	err = yaml.Unmarshal(contents, &conf)
-	if err == nil {
-		return conf.Initialize(), err
+func LoadConfiguration(contents []byte) (Configuration, error) {
+	var conf Configuration
+	if err := yaml.Unmarshal(contents, &conf); err != nil {
+		return conf, err
 	}
-	return
+	return conf.Initialize()
 }
 
-func (conf Configuration) Initialize() Configuration {
+func (conf Configuration) Initialize() (Configuration, error) {
 	if conf.BucketSize <= 0 {
 		conf.BucketSize = DefaultBucketSize
 	}
@@ -51,7 +51,14 @@ func (conf Configuration) Initialize() Configuration {
 	if conf.ThemeId != 0 {
 		conf.Url = fmt.Sprintf("%s/themes/%d", conf.Url, conf.ThemeId)
 	}
-	return conf
+
+	if len(conf.Domain) == 0 {
+		return conf, fmt.Errorf("missing domain")
+	}
+	if len(conf.AccessToken) == 0 {
+		return conf, fmt.Errorf("missing access_token")
+	}
+	return conf, nil
 }
 
 func (conf Configuration) AdminUrl() string {

--- a/configuration_test.go
+++ b/configuration_test.go
@@ -43,6 +43,21 @@ func TestLoadingAnUnsupportedConfiguration(t *testing.T) {
 	assert.Equal(t, "abracadabra", config.AccessToken)
 }
 
+func TestLoadingConfigurationWithMissingFields(t *testing.T) {
+	tests := []struct {
+		src, expectedError string
+	}{
+		{configurationWithoutAccessToken, "missing access_token"},
+		{configurationWithoutDomain, "missing domain"},
+	}
+
+	for _, data := range tests {
+		_, err := LoadConfiguration([]byte(data.src))
+		assert.NotNil(t, err)
+		assert.Equal(t, data.expectedError, err.Error())
+	}
+}
+
 func TestWritingAConfigurationFile(t *testing.T) {
 	buffer := new(bytes.Buffer)
 	config := Configuration{Domain: "hello.myshopify.com", AccessToken: "secret", BucketSize: 10, RefillRate: 4}
@@ -94,5 +109,14 @@ const (
   store: example.myshopify.com
   access_token: abracadabra
   theme_id: 12345
+  `
+
+	configurationWithoutAccessToken = `
+  store: foo.myshopify.com
+  theme_id: 123
+  `
+
+	configurationWithoutDomain = `
+  access_token: foobar
   `
 )

--- a/environments.go
+++ b/environments.go
@@ -17,7 +17,11 @@ func LoadEnvironments(contents []byte) (envs Environments, err error) {
 	err = yaml.Unmarshal(contents, &envs)
 	if err == nil {
 		for key, conf := range envs {
-			envs[key] = conf.Initialize()
+			environmentConfig, err := conf.Initialize()
+			if err != nil {
+				return nil, err
+			}
+			envs[key] = environmentConfig
 		}
 	}
 	return

--- a/environments.go
+++ b/environments.go
@@ -19,7 +19,7 @@ func LoadEnvironments(contents []byte) (envs Environments, err error) {
 		for key, conf := range envs {
 			environmentConfig, err := conf.Initialize()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("could not load environment \"%s\": %s", key, err)
 			}
 			envs[key] = environmentConfig
 		}

--- a/theme_client.go
+++ b/theme_client.go
@@ -215,9 +215,13 @@ func (t ThemeClient) CreateTheme(name, zipLocation string) (ThemeClient, chan Th
 	}()
 
 	wg.Wait()
-	config := t.GetConfiguration()
+	config := t.GetConfiguration() // Shouldn't this configuration already be loaded and initialized?
 	config.ThemeId = themeEvent.ThemeId
-	return NewThemeClient(config.Initialize()), log
+	config, err := config.Initialize()
+	if err != nil {
+		// TODO: there's no way we can signal that something went wrong.
+	}
+	return NewThemeClient(config), log
 }
 
 func (t ThemeClient) Process(events chan AssetEvent) (done chan bool, messages chan ThemeEvent) {


### PR DESCRIPTION
Configurations now receive some rudimentary checks to ensure they are valid. Missing access tokens or shop domain will now cause an error indicating what environment failed and what key is missing. 

Fixes #119  (hopefully)

@chrisbutcher 