### PR TITLE
Using WriteString instead of Write([]byte)

### DIFF
--- a/cmd/theme/main.go
+++ b/cmd/theme/main.go
@@ -5,12 +5,13 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"github.com/Shopify/themekit"
-	"github.com/Shopify/themekit/commands"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/Shopify/themekit"
+	"github.com/Shopify/themekit/commands"
 )
 
 const banner string = "----------------------------------------"
@@ -129,7 +130,7 @@ func main() {
 			select {
 			case event := <-globalEventLog:
 				if len(event.String()) > 0 {
-					output.Write([]byte(fmt.Sprintf("%s\n", event)))
+					output.WriteString(fmt.Sprintf("%s\n", event))
 					output.Flush()
 				}
 			case <-time.Tick(1000 * time.Millisecond):
@@ -220,11 +221,11 @@ func BootstrapParser(cmd string, args []string) (result map[string]interface{}, 
 	result = make(map[string]interface{})
 	currentDir, _ := os.Getwd()
 	var version, directory, environment, prefix string
-	var setThemeId bool
+	var setThemeID bool
 
 	set = makeFlagSet(cmd)
 	set.StringVar(&directory, "dir", currentDir, "location of config.yml")
-	set.BoolVar(&setThemeId, "setid", true, "update config.yml with ID of created Theme")
+	set.BoolVar(&setThemeID, "setid", true, "update config.yml with ID of created Theme")
 	set.StringVar(&environment, "env", themekit.DefaultEnvironment, "environment to execute command")
 	set.StringVar(&version, "version", commands.LatestRelease, "version of Shopify Timber to use")
 	set.StringVar(&prefix, "prefix", "", "prefix to the Timber theme being created")
@@ -234,7 +235,7 @@ func BootstrapParser(cmd string, args []string) (result map[string]interface{}, 
 	result["directory"] = directory
 	result["environment"] = environment
 	result["prefix"] = prefix
-	result["setThemeId"] = setThemeId
+	result["setThemeId"] = setThemeID
 	result["themeClient"] = loadThemeClient(directory, environment)
 	return
 }
@@ -254,7 +255,7 @@ func loadThemeClientWithRetry(directory, env string, isRetry bool) (themekit.The
 	if err != nil && len(environments) > 0 {
 		invalidEnvMsg := fmt.Sprintf("'%s' is not a valid environment. The following environments are available within config.yml:", env)
 		fmt.Println(themekit.RedText(invalidEnvMsg))
-		for e, _ := range environments {
+		for e := range environments {
 			fmt.Println(themekit.RedText(fmt.Sprintf(" - %s", e)))
 		}
 		os.Exit(1)
@@ -341,9 +342,9 @@ func handleError(err error) {
 	}
 
 	if strings.Contains(err.Error(), "YAML error") {
-		err = errors.New(fmt.Sprintf("configuration error: does your configuration properly escape wildcards? \n\t\t\t%s", err))
+		err = fmt.Errorf("configuration error: does your configuration properly escape wildcards? \n\t\t\t%s", err)
 	} else if strings.Contains(err.Error(), "no such file or directory") {
-		err = errors.New(fmt.Sprintf("configuration error: %s", err))
+		err = fmt.Errorf("configuration error: %s", err)
 	}
 	themekit.NotifyErrorImmediately(err)
 }

--- a/commands/bootstrap.go
+++ b/commands/bootstrap.go
@@ -23,7 +23,7 @@ type BootstrapOptions struct {
 	Directory   string
 	Environment string
 	Prefix      string
-	SetThemeId  bool
+	SetThemeID  bool
 }
 
 func BootstrapCommand(args map[string]interface{}) chan bool {
@@ -33,7 +33,7 @@ func BootstrapCommand(args map[string]interface{}) chan bool {
 	extractString(&options.Directory, "directory", args)
 	extractString(&options.Environment, "environment", args)
 	extractString(&options.Prefix, "prefix", args)
-	extractBool(&options.SetThemeId, "setThemeId", args)
+	extractBool(&options.SetThemeID, "setThemeId", args)
 	extractThemeClient(&options.Client, args)
 	extractEventLog(&options.EventLog, args)
 
@@ -69,7 +69,7 @@ func doBootstrap(options BootstrapOptions) chan bool {
 	}
 	clientForNewTheme, themeEvents := options.Client.CreateTheme(name, zipLocation)
 	mergeEvents(options.getEventLog(), []chan themekit.ThemeEvent{themeEvents})
-	if options.SetThemeId {
+	if options.SetThemeID {
 		AddConfiguration(options.Directory, options.Environment, clientForNewTheme.GetConfiguration())
 	}
 
@@ -134,12 +134,12 @@ func findReleaseWith(feed atom.Feed, version string) (atom.Entry, error) {
 
 func buildInvalidVersionError(feed atom.Feed, version string) error {
 	buff := bytes.NewBuffer([]byte{})
-	buff.Write([]byte(themekit.RedText("Invalid Timber Version: " + version)))
-	buff.Write([]byte("\nAvailable Versions Are:"))
-	buff.Write([]byte("\n  - master"))
-	buff.Write([]byte("\n  - latest"))
+	buff.WriteString(themekit.RedText("Invalid Timber Version: " + version))
+	buff.WriteString("\nAvailable Versions Are:")
+	buff.WriteString("\n  - master")
+	buff.WriteString("\n  - latest")
 	for _, entry := range feed.Entries {
-		buff.Write([]byte("\n  - " + entry.Title))
+		buff.WriteString("\n  - " + entry.Title)
 	}
 	return errors.New(buff.String())
 }

--- a/theme/asset_test.go
+++ b/theme/asset_test.go
@@ -2,8 +2,6 @@ package theme
 
 import (
 	"bytes"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/suite"
 	"image"
 	"image/png"
 	"io/ioutil"
@@ -13,6 +11,9 @@ import (
 	"sort"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 )
 
 type LoadAssetSuite struct {
@@ -108,7 +109,7 @@ func (s *LoadAssetSuite) allocateFileInDir(directory, content string) (root, fil
 	}
 
 	if len(content) > 0 {
-		file.Write([]byte(content))
+		file.WriteString(content)
 		file.Sync()
 		file.Seek(0, 0)
 	}


### PR DESCRIPTION
io.WriteString() is more optimized for cases when the argument given is already evaluated as a string. This PR uses it any place we'd otherwise do `Write([]byte(fmt.Sprintf("Foo %s", "bar"))) etc`. Cleaner and faster!

+ Lint-based style changes

@ilikeorangutans for review