### PR TITLE
Cleanups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ all:
 	  godep go build -o build/development/$${subproject} github.com/Shopify/themekit/cmd/$${subproject}; \
   done
 
+install: 
+	godep go install github.com/Shopify/themekit/cmd/theme 
+
 build:
 	for subproject in $(SUBPROJECTS); \
 	do \

--- a/bucket/leaky_bucket.go
+++ b/bucket/leaky_bucket.go
@@ -1,7 +1,6 @@
 package bucket
 
 import (
-	"log"
 	"time"
 )
 
@@ -70,7 +69,6 @@ func (b *LeakyBucket) AddDrops() {
 }
 
 func (b *LeakyBucket) GetDrop() {
-	log.Println("Getting drop ", len(b.bucket), "available")
 	<-b.bucket
 }
 

--- a/theme_client_test.go
+++ b/theme_client_test.go
@@ -101,6 +101,7 @@ func TestRetrievingLocalAssets(t *testing.T) {
 
 	dir, _ := os.Getwd()
 	assets := client.LocalAssets(fmt.Sprintf("%s/fixtures/templates", dir))
+
 	assert.Equal(t, 1, len(assets))
 }
 


### PR DESCRIPTION
Various minor fixes and improvements: 

* `install` target for Makefile that installs the binary. Got tired of always doing that myself. 
* removed some debug output in leaky bucket
* moved loading assets from a local directory out of `ThemeClient` into its own method next to Asset. 

Review: @chrisbutcher 