### PR TITLE
Fixes a strange crash

### DIFF
--- a/event_filter.go
+++ b/event_filter.go
@@ -94,6 +94,9 @@ func (e EventFilter) Filter(events chan string) chan string {
 }
 
 func (e EventFilter) MatchesFilter(event string) bool {
+	if len(event) == 0 {
+		return false
+	}
 	for _, regexp := range e.filters {
 		if regexp.MatchString(event) {
 			return true

--- a/event_filter_test.go
+++ b/event_filter_test.go
@@ -52,6 +52,12 @@ func TestDefaultFilters(t *testing.T) {
 	assertFilter(t, eventFilter, inputEvents, expectedEvents)
 }
 
+func TestMatchesFilterWithEmptyInputDoesNotCrash(t *testing.T) {
+	eventFilter := NewEventFilter([]string{"config/settings_schema.json", "config/settings_data.json", "*.jpg", "*.png"})
+	// Shouldn't crash
+	eventFilter.MatchesFilter("")
+}
+
 func nextValue(channel chan string) string {
 	select {
 	case result := <-channel:


### PR DESCRIPTION
Fixes #140

Passing an empty string to the glob function crashed themekit. Added
simple check. Need to figure out why we even handled an empty string at
that point.

@chrisbutcher @stevebosworth 