### PR TITLE
Support 'password' in config, interchangeable with access_token

### DIFF
--- a/cmd/theme/main.go
+++ b/cmd/theme/main.go
@@ -275,6 +275,10 @@ func loadThemeClientWithRetry(directory, env string, isRetry bool) (themekit.The
 		return themekit.ThemeClient{}, err
 	}
 
+	if len(config.AccessToken) > 0 {
+		fmt.Println("DEPRECATION WARNING: 'access_token' (in conf.yml) will soon be deprecated. Use 'password' instead, with the same Password value obtained from https://<your-subdomain>.myshopify.com/admin/apps/private/<app_id>")
+	}
+
 	return themekit.NewThemeClient(config), nil
 }
 

--- a/cmd/theme/main.go
+++ b/cmd/theme/main.go
@@ -196,14 +196,15 @@ func WatchCommandParser(cmd string, args []string) (result map[string]interface{
 func ConfigurationCommandParser(cmd string, args []string) (result map[string]interface{}, set *flag.FlagSet) {
 	result = make(map[string]interface{})
 	currentDir, _ := os.Getwd()
-	var directory, environment, domain, accessToken string
+	var directory, environment, domain, password, access_token string
 	var bucketSize, refillRate int
 
 	set = makeFlagSet(cmd)
 	set.StringVar(&directory, "dir", currentDir, "directory to create config.yml")
 	set.StringVar(&environment, "env", themekit.DefaultEnvironment, "environment for this configuration")
 	set.StringVar(&domain, "domain", "", "your myshopify domain")
-	set.StringVar(&accessToken, "access_token", "", "accessToken (or password) to make successful API calls")
+	set.StringVar(&password, "password", "", "password (or access token) to make successful API calls")
+	set.StringVar(&access_token, "access_token", "", "access_token to make successful API calls (optional, and soon to be deprecated in favour of 'password')")
 	set.IntVar(&bucketSize, "bucketSize", themekit.DefaultBucketSize, "leaky bucket capacity")
 	set.IntVar(&refillRate, "refillRate", themekit.DefaultRefillRate, "leaky bucket refill rate / second")
 	set.Parse(args)
@@ -211,7 +212,8 @@ func ConfigurationCommandParser(cmd string, args []string) (result map[string]in
 	result["directory"] = directory
 	result["environment"] = environment
 	result["domain"] = domain
-	result["access_token"] = accessToken
+	result["password"] = password
+	result["access_token"] = access_token
 	result["bucket_size"] = bucketSize
 	result["refill_rate"] = refillRate
 	return

--- a/configuration.go
+++ b/configuration.go
@@ -57,7 +57,7 @@ func (conf Configuration) Initialize() (Configuration, error) {
 
 	if len(conf.Domain) == 0 {
 		return conf, fmt.Errorf("missing domain")
-	} else if !strings.HasSuffix(conf.Domain, "myshopify.com") {
+	} else if !strings.HasSuffix(conf.Domain, "myshopify.com") && !strings.HasSuffix(conf.Domain, "myshopify.io") {
 		return conf, fmt.Errorf("invalid domain, must end in '.myshopify.com'")
 	}
 

--- a/configuration.go
+++ b/configuration.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"runtime"
+	"strings"
 
 	"gopkg.in/yaml.v1"
 )
@@ -56,9 +57,12 @@ func (conf Configuration) Initialize() (Configuration, error) {
 
 	if len(conf.Domain) == 0 {
 		return conf, fmt.Errorf("missing domain")
+	} else if !strings.HasSuffix(conf.Domain, "myshopify.com") {
+		return conf, fmt.Errorf("invalid domain, must end in '.myshopify.com'")
 	}
+
 	if len(conf.AccessToken) == 0 && len(conf.Password) == 0 {
-		return conf, fmt.Errorf("missing password or access_token")
+		return conf, fmt.Errorf("missing password or access_token (using 'password' is encouraged. 'access_token', which does the same thing will be deprecated soon)")
 	}
 	return conf, nil
 }

--- a/configuration_test.go
+++ b/configuration_test.go
@@ -2,11 +2,12 @@ package themekit
 
 import (
 	"bytes"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestLoadingAValidConfiguration(t *testing.T) {
@@ -47,7 +48,7 @@ func TestLoadingConfigurationWithMissingFields(t *testing.T) {
 	tests := []struct {
 		src, expectedError string
 	}{
-		{configurationWithoutAccessToken, "missing access_token"},
+		{configurationWithoutAccessTokenAndPassword, "missing password or access_token"},
 		{configurationWithoutDomain, "missing domain"},
 	}
 
@@ -111,7 +112,7 @@ const (
   theme_id: 12345
   `
 
-	configurationWithoutAccessToken = `
+	configurationWithoutAccessTokenAndPassword = `
   store: foo.myshopify.com
   theme_id: 123
   `

--- a/configuration_test.go
+++ b/configuration_test.go
@@ -14,7 +14,7 @@ func TestLoadingAValidConfiguration(t *testing.T) {
 	config, err := LoadConfiguration([]byte(validConfiguration))
 	assert.Nil(t, err)
 	assert.Equal(t, "example.myshopify.com", config.Domain)
-	assert.Equal(t, "abracadabra", config.AccessToken)
+	assert.Equal(t, "abracadabra", config.Password)
 	assert.Equal(t, "https://example.myshopify.com/admin", config.Url)
 	assert.Equal(t, "https://example.myshopify.com/admin/assets.json", config.AssetPath())
 	assert.Equal(t, 4, config.Concurrency)
@@ -25,31 +25,32 @@ func TestLoadingAValidConfigurationWithIgnoredFiles(t *testing.T) {
 	config, err := LoadConfiguration([]byte(validConfigurationWithIgnoredFiles))
 	assert.Nil(t, err)
 	assert.Equal(t, "example.myshopify.com", config.Domain)
-	assert.Equal(t, "abracadabra", config.AccessToken)
+	assert.Equal(t, "abracadabra", config.Password)
 	assert.Equal(t, []string{"charmander", "bulbasaur", "squirtle"}, config.IgnoredFiles)
 }
 
 func TestLoadingAValidConfigurationWithAThemeId(t *testing.T) {
-	config, err := LoadConfiguration([]byte(validConfigurationWithThemeId))
+	config, err := LoadConfiguration([]byte(validConfigurationWithThemeID))
 	assert.Nil(t, err)
 	assert.Equal(t, 1234, config.ThemeId)
 	assert.Equal(t, "https://example.myshopify.com/admin/themes/1234", config.Url)
 	assert.Equal(t, "https://example.myshopify.com/admin/themes/1234/assets.json", config.AssetPath())
 }
 
-func TestLoadingAnUnsupportedConfiguration(t *testing.T) {
-	config, err := LoadConfiguration([]byte(unsupportedConfiguration))
+func TestLoadingSupportedConfiguration(t *testing.T) {
+	config, err := LoadConfiguration([]byte(supportedConfiguration))
 	assert.Nil(t, err)
 	assert.Equal(t, "example.myshopify.com", config.Domain)
-	assert.Equal(t, "abracadabra", config.AccessToken)
+	assert.Equal(t, "abracadabra", config.Password)
 }
 
 func TestLoadingConfigurationWithMissingFields(t *testing.T) {
 	tests := []struct {
 		src, expectedError string
 	}{
-		{configurationWithoutAccessTokenAndPassword, "missing password or access_token"},
+		{configurationWithoutAccessTokenAndPassword, "missing password or access_token (using 'password' is encouraged. 'access_token', which does the same thing will be deprecated soon)"},
 		{configurationWithoutDomain, "missing domain"},
+		{configurationWithInvalidDomain, "invalid domain, must end in '.myshopify.com'"},
 	}
 
 	for _, data := range tests {
@@ -87,28 +88,28 @@ func TestAddHeadersAddsPlatformAndArchitecture(t *testing.T) {
 const (
 	validConfiguration = `
   store: example.myshopify.com
-  access_token: abracadabra
+  password: abracadabra
   concurrency: 4
   `
 
-	validConfigurationWithThemeId = `
+	validConfigurationWithThemeID = `
   store: example.myshopify.com
-  access_token: abracadabra
+  password: abracadabra
   theme_id: 1234
   `
 
 	validConfigurationWithIgnoredFiles = `
   store: example.myshopify.com
-  access_token: abracadabra
+  password: abracadabra
   ignore_files:
     - charmander
     - bulbasaur
     - squirtle
   `
 
-	unsupportedConfiguration = `
+	supportedConfiguration = `
   store: example.myshopify.com
-  access_token: abracadabra
+  password: abracadabra
   theme_id: 12345
   `
 
@@ -118,6 +119,12 @@ const (
   `
 
 	configurationWithoutDomain = `
-  access_token: foobar
+  password: foobar
+  `
+
+	configurationWithInvalidDomain = `
+  store: example.something.net
+  password: abracadabra
+  theme_id: 12345
   `
 )

--- a/version.go
+++ b/version.go
@@ -5,13 +5,14 @@ import (
 	_ "crypto/md5"
 	"encoding/hex"
 	"fmt"
-	"github.com/inconshreveable/go-update"
 	"net/http"
 	"strconv"
 	"strings"
+
+	"github.com/inconshreveable/go-update"
 )
 
-var TKVersion Version = Version{Major: 0, Minor: 3, Patch: 5}
+var TKVersion Version = Version{Major: 0, Minor: 3, Patch: 6}
 var ThemeKitVersion string = TKVersion.String()
 
 type VersionComparisonResult int


### PR DESCRIPTION
Part of https://github.com/Shopify/themekit/issues/104

* Adds `password` to Configure command workflow, which holds the same value sent to Shopify under the header `X-Shopify-Access-Token`.
  * The logic which allows either to be used interchangeably is [here](https://github.com/Shopify/themekit/pull/145/files#diff-bee1b19602a9f84a06f44e111f79a479R93).
  * The naming of this header is a source of confusion. In the previous themes gem, and in previous incarnations of `config.yml`, the term `password` is used. It's also used within the Shopify Private Apps UI, as seen in the related issue above.
* This PR adds support for `password` as the preferred flag name, and `config.yml` key. Eventually we should deprecate the term `access_token` themekit (a warning is added when calling `theme configure` with `-access_token=foo`).

Following my configuration refactor PR shipping, a lot of the duplication still visible in parts of this PR will be cleaned up. https://github.com/Shopify/themekit/pull/135

Please review, @ilikeorangutans cc: @stevebosworth @cshold 