### PR TITLE
Handle blank or non-integer theme_id specified in config.yml

### DIFF
--- a/cmd/theme/main.go
+++ b/cmd/theme/main.go
@@ -225,6 +225,7 @@ func configurationArgsParser(cmd string, rawArgs []string) commands.Args {
 	set.StringVar(&args.Directory, "dir", currentDir, "directory to create config.yml")
 	set.StringVar(&args.Environment, "env", themekit.DefaultEnvironment, "environment for this configuration")
 	set.StringVar(&args.Domain, "domain", "", "your myshopify domain")
+	set.StringVar(&args.ThemeID, "theme_id", "", "your theme's id (i.e. https://<your shop>.myshopify.com/admin/themes/<theme_id>/)")
 	set.StringVar(&args.Password, "password", "", "password (or access token) to make successful API calls")
 	set.StringVar(&args.AccessToken, "access_token", "", "access_token to make successful API calls (optional, and soon to be deprecated in favour of 'password')")
 	set.IntVar(&args.BucketSize, "bucketSize", themekit.DefaultBucketSize, "leaky bucket capacity")

--- a/commands/args.go
+++ b/commands/args.go
@@ -25,6 +25,7 @@ type Args struct {
 	NotifyFile   string
 	Prefix       string
 	Version      string
+	ThemeID      string
 	SetThemeID   bool
 	BucketSize   int
 	RefillRate   int
@@ -53,11 +54,17 @@ type WorkingDirGetterType func() (string, error)
 
 // DefaultConfigurationOptions returns a default themekit.Configuration using fields from an Args instance
 func (args Args) DefaultConfigurationOptions() themekit.Configuration {
+	accessToken := args.AccessToken
+	if args.AccessToken == "" {
+		accessToken = args.Password
+	}
+
 	return themekit.Configuration{
-		Domain:      args.Domain,
-		AccessToken: args.AccessToken,
-		BucketSize:  args.BucketSize,
-		RefillRate:  args.RefillRate,
+		Domain:     args.Domain,
+		Password:   accessToken,
+		BucketSize: args.BucketSize,
+		RefillRate: args.RefillRate,
+		ThemeID:    args.ThemeID,
 	}
 }
 

--- a/commands/configure.go
+++ b/commands/configure.go
@@ -26,6 +26,12 @@ func ConfigureCommand(args Args) chan bool {
 // Configure ... TODO
 func Configure(args Args) {
 	config := args.DefaultConfigurationOptions()
+	_, err := config.Initialize()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
 	AddConfiguration(args.Directory, args.Environment, config)
 }
 
@@ -99,7 +105,12 @@ func loadOrInitializeEnvironment(location string) (themekit.Environments, error)
 	}
 
 	env, err := themekit.LoadEnvironments(contents)
-	if (err != nil && canProcessWithError(err)) || len(env) <= 0 {
+
+	if err != nil && !canProcessWithError(err) {
+		return env, err
+	}
+
+	if err != nil || len(env) <= 0 {
 		conf, _ := themekit.LoadConfiguration(contents)
 		env[themekit.DefaultEnvironment] = conf
 	}
@@ -107,5 +118,9 @@ func loadOrInitializeEnvironment(location string) (themekit.Environments, error)
 }
 
 func canProcessWithError(e error) bool {
-	return strings.Contains(e.Error(), "YAML error") == false
+	if strings.Contains(e.Error(), "YAML error") == false {
+		return false
+	}
+
+	return true
 }

--- a/configuration.go
+++ b/configuration.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"runtime"
+	"strconv"
 	"strings"
 
 	"gopkg.in/yaml.v1"
@@ -15,7 +16,7 @@ import (
 type Configuration struct {
 	AccessToken  string   `yaml:"access_token,omitempty"`
 	Password     string   `yaml:"password,omitempty"`
-	ThemeID      int64    `yaml:"theme_id,omitempty"`
+	ThemeID      string   `yaml:"theme_id,omitempty"`
 	Domain       string   `yaml:"store"`
 	URL          string   `yaml:"-"`
 	IgnoredFiles []string `yaml:"ignore_files,omitempty"`
@@ -57,8 +58,11 @@ func (conf Configuration) Initialize() (Configuration, error) {
 	}
 
 	conf.URL = conf.AdminURL()
-	if conf.ThemeID != 0 {
-		conf.URL = fmt.Sprintf("%s/themes/%d", conf.URL, conf.ThemeID)
+
+	if themeID, err := strconv.ParseInt(conf.ThemeID, 10, 64); err == nil {
+		conf.URL = fmt.Sprintf("%s/themes/%d", conf.URL, themeID)
+	} else {
+		return conf, fmt.Errorf("missing theme_id")
 	}
 
 	if len(conf.Domain) == 0 {

--- a/configuration.go
+++ b/configuration.go
@@ -59,10 +59,14 @@ func (conf Configuration) Initialize() (Configuration, error) {
 
 	conf.URL = conf.AdminURL()
 
-	if themeID, err := strconv.ParseInt(conf.ThemeID, 10, 64); err == nil {
-		conf.URL = fmt.Sprintf("%s/themes/%d", conf.URL, themeID)
-	} else {
-		return conf, fmt.Errorf("missing theme_id")
+	if !(strings.ToLower(strings.TrimSpace(conf.ThemeID)) == "live") {
+		// theme_id may be specified as 'live', indicating that the user
+		// is opting into always syncing to the current, production theme
+		if themeID, err := strconv.ParseInt(conf.ThemeID, 10, 64); err == nil {
+			conf.URL = fmt.Sprintf("%s/themes/%d", conf.URL, themeID)
+		} else {
+			return conf, fmt.Errorf("missing theme_id. Error: \"%s\"", err)
+		}
 	}
 
 	if len(conf.Domain) == 0 {

--- a/configuration_test.go
+++ b/configuration_test.go
@@ -21,6 +21,17 @@ func TestLoadingAValidConfiguration(t *testing.T) {
 	assert.Nil(t, config.IgnoredFiles)
 }
 
+func TestLoadingAValidConfigurationWithLiveTheme(t *testing.T) {
+	config, err := LoadConfiguration([]byte(validConfigurationWithLiveTheme))
+	assert.Nil(t, err)
+	assert.Equal(t, "example.myshopify.com", config.Domain)
+	assert.Equal(t, "abracadabra", config.Password)
+	assert.Equal(t, "https://example.myshopify.com/admin", config.URL)
+	assert.Equal(t, "https://example.myshopify.com/admin/assets.json", config.AssetPath())
+	assert.Equal(t, 4, config.Concurrency)
+	assert.Nil(t, config.IgnoredFiles)
+}
+
 func TestLoadingAValidConfigurationWithIgnoredFiles(t *testing.T) {
 	config, err := LoadConfiguration([]byte(validConfigurationWithIgnoredFiles))
 	assert.Nil(t, err)
@@ -83,6 +94,13 @@ const (
   password: abracadabra
   concurrency: 4
   theme_id: 1234
+  `
+
+	validConfigurationWithLiveTheme = `
+  store: example.myshopify.com
+  password: abracadabra
+  concurrency: 4
+  theme_id: live
   `
 
 	validConfigurationWithIgnoredFiles = `

--- a/configuration_test.go
+++ b/configuration_test.go
@@ -15,8 +15,8 @@ func TestLoadingAValidConfiguration(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "example.myshopify.com", config.Domain)
 	assert.Equal(t, "abracadabra", config.Password)
-	assert.Equal(t, "https://example.myshopify.com/admin", config.URL)
-	assert.Equal(t, "https://example.myshopify.com/admin/assets.json", config.AssetPath())
+	assert.Equal(t, "https://example.myshopify.com/admin/themes/1234", config.URL)
+	assert.Equal(t, "https://example.myshopify.com/admin/themes/1234/assets.json", config.AssetPath())
 	assert.Equal(t, 4, config.Concurrency)
 	assert.Nil(t, config.IgnoredFiles)
 }
@@ -27,14 +27,6 @@ func TestLoadingAValidConfigurationWithIgnoredFiles(t *testing.T) {
 	assert.Equal(t, "example.myshopify.com", config.Domain)
 	assert.Equal(t, "abracadabra", config.Password)
 	assert.Equal(t, []string{"charmander", "bulbasaur", "squirtle"}, config.IgnoredFiles)
-}
-
-func TestLoadingAValidConfigurationWithAThemeId(t *testing.T) {
-	config, err := LoadConfiguration([]byte(validConfigurationWithThemeID))
-	assert.Nil(t, err)
-	assert.Equal(t, 1234, config.ThemeID)
-	assert.Equal(t, "https://example.myshopify.com/admin/themes/1234", config.URL)
-	assert.Equal(t, "https://example.myshopify.com/admin/themes/1234/assets.json", config.AssetPath())
 }
 
 func TestLoadingSupportedConfiguration(t *testing.T) {
@@ -90,17 +82,13 @@ const (
   store: example.myshopify.com
   password: abracadabra
   concurrency: 4
-  `
-
-	validConfigurationWithThemeID = `
-  store: example.myshopify.com
-  password: abracadabra
   theme_id: 1234
   `
 
 	validConfigurationWithIgnoredFiles = `
   store: example.myshopify.com
   password: abracadabra
+  theme_id: 1234
   ignore_files:
     - charmander
     - bulbasaur
@@ -120,11 +108,12 @@ const (
 
 	configurationWithoutDomain = `
   password: foobar
+  theme_id: 1234
   `
 
 	configurationWithInvalidDomain = `
   store: example.something.net
   password: abracadabra
-  theme_id: 12345
+  theme_id: 1234
   `
 )

--- a/environments_test.go
+++ b/environments_test.go
@@ -25,7 +25,7 @@ func TestRetrievingAConfigurationFromAnEnvironment(t *testing.T) {
 	env, err := LoadEnvironmentsFromFile(goodEnv)
 	conf, err := env.GetConfiguration("default")
 	assert.NoError(t, err, "Retrieving the 'default' env should not have raised an error")
-	assert.Equal(t, conf.ThemeID, 2)
+	assert.Equal(t, conf.ThemeID, "2")
 }
 
 func TestRetrievingAnInvalidConfigurationFromAnEnvironment(t *testing.T) {

--- a/theme_client.go
+++ b/theme_client.go
@@ -224,7 +224,7 @@ func (t ThemeClient) CreateTheme(name, zipLocation string) (ThemeClient, chan Th
 
 	wg.Wait()
 	config := t.GetConfiguration() // Shouldn't this configuration already be loaded and initialized?
-	config.ThemeID = themeEvent.ThemeID
+	config.ThemeID = fmt.Sprintf("%d", themeEvent.ThemeID)
 	config, err := config.Initialize()
 	if err != nil {
 		// TODO: there's no way we can signal that something went wrong.


### PR DESCRIPTION
Fixes https://github.com/Shopify/themekit/issues/157

* Parse theme_id in config.yml as an integer, to ensure it's valid (at least numerical)
* Enforce required values in `theme configure` (TODO update docs)
  * domain
  * password
  * theme_id (now required)