### PR TITLE
Adds ruby to dev up for easy setup

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -2,6 +2,7 @@ name: themekit
 
 up:
   - go: 1.6.2
+  - ruby: 2.2.3p172-shopify
 
 commands:
   test:


### PR DESCRIPTION
I received `failed to activate ruby 2.2.3. you may need to run dev up.` when trying to run `make install` after running `dev up`. 