### PR TITLE
Adding in theme id to the default config args

### DIFF
--- a/commands/args.go
+++ b/commands/args.go
@@ -69,6 +69,7 @@ func (args Args) DefaultConfigurationOptions() themekit.Configuration {
 		BucketSize:  args.BucketSize,
 		RefillRate:  args.RefillRate,
 		Timeout:     args.Timeout,
+		ThemeID:     args.ThemeID,
 	}
 }
 


### PR DESCRIPTION
I found that I could not use `theme configure` because the `theme_id` argument was not passed along and it was required. So I added this into the default config options so that it is passed along to the config command.

cc @chrisbutcher @ilikeorangutans 