### PR TITLE
Validate Environment only when required

### DIFF
--- a/cmd/theme/main.go
+++ b/cmd/theme/main.go
@@ -319,11 +319,7 @@ func loadThemeClientWithRetry(directory, env string, isRetry bool) (kit.ThemeCli
 	}
 	config, err := environments.GetConfiguration(env)
 	if err != nil && len(environments) > 0 {
-		invalidEnvMsg := fmt.Sprintf("'%s' is not a valid environment. The following environments are available within config.yml:", env)
-		fmt.Println(kit.RedText(invalidEnvMsg))
-		for e := range environments {
-			fmt.Println(kit.RedText(fmt.Sprintf(" - %s", e)))
-		}
+		fmt.Println(kit.RedText(err.Error()))
 		os.Exit(1)
 	} else if err != nil && !isRetry {
 		upgradeMessage := fmt.Sprintf("Looks like your configuration file is out of date. Upgrading to default environment '%s'", kit.DefaultEnvironment)

--- a/kit/configuration.go
+++ b/kit/configuration.go
@@ -72,7 +72,7 @@ func (conf Configuration) Initialize() (Configuration, error) {
 		if themeID, err := strconv.ParseInt(conf.ThemeID, 10, 64); err == nil {
 			conf.URL = fmt.Sprintf("%s/themes/%d", conf.URL, themeID)
 		} else {
-			return conf, fmt.Errorf("missing theme_id. Error: \"%s\"", err)
+			return conf, fmt.Errorf("missing theme_id.")
 		}
 	}
 

--- a/kit/environments.go
+++ b/kit/environments.go
@@ -22,13 +22,6 @@ func LoadEnvironments(contents []byte) (envs Environments, err error) {
 	if err != nil {
 		return nil, err
 	}
-	for key, conf := range envs {
-		environmentConfig, err := conf.Initialize()
-		if err != nil {
-			return nil, fmt.Errorf("could not load environment \"%s\": %s", key, err)
-		}
-		envs[key] = environmentConfig
-	}
 	return
 }
 
@@ -41,9 +34,15 @@ func (e Environments) SetConfiguration(environmentName string, conf Configuratio
 func (e Environments) GetConfiguration(environmentName string) (conf Configuration, err error) {
 	conf, exists := e[environmentName]
 	if !exists {
-		err = fmt.Errorf("%s does not exist in this environments list", environmentName)
+		return conf, fmt.Errorf("%s does not exist in this environments list", environmentName)
 	}
-	return
+
+	validConfig, err := conf.Initialize()
+	if err != nil {
+		return conf, fmt.Errorf("could not load environment \"%s\": %s", environmentName, err)
+	}
+
+	return validConfig, nil
 }
 
 func (e Environments) Write(w io.Writer) error {


### PR DESCRIPTION
fixes https://github.com/Shopify/themekit/issues/175

Just changed the validation of configurations to only happen when they are fetched using `GetConfiguration` rather than when all of the environments are unmarshaled.