### PR TITLE
Took out bad debounce logic

### DIFF
--- a/kit/file_watcher.go
+++ b/kit/file_watcher.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	debounceTimeout = 50 * time.Millisecond
+	debounceTimeout = 500 * time.Millisecond
 )
 
 var (

--- a/kit/file_watcher.go
+++ b/kit/file_watcher.go
@@ -146,14 +146,10 @@ func convertFsEvents(events chan fsnotify.Event, filter eventFilter) chan AssetE
 		var currentEvent fsnotify.Event
 		recordedEvents := map[string]fsnotify.Event{}
 		for {
-			currentEvent = <-events
-			if currentEvent.Op&fsnotify.Chmod != fsnotify.Chmod {
-				recordedEvents[currentEvent.Name] = currentEvent
-			}
 			select {
 			case currentEvent = <-events:
 				if currentEvent.Op&fsnotify.Chmod == fsnotify.Chmod {
-					continue
+					currentEvent.Op = fsnotify.Write
 				}
 				recordedEvents[currentEvent.Name] = currentEvent
 			case <-time.After(debounceTimeout):


### PR DESCRIPTION
v0.4.4 was release with bad file watching debouncing. This will fix that. This was my fault. I tried to be overzealous with refactoring it so that the timeout didn't run constantly and then have a low timeout for better responce. My logic was faulty so I have reverted it and made the timeout higher to filter events better.

cc @chrisbutcher @ilikeorangutans 

ref https://github.com/Shopify/themekit/issues/220