### PR TITLE
More dependable downloads

### DIFF
--- a/commands/download.go
+++ b/commands/download.go
@@ -16,46 +16,52 @@ import (
 func DownloadCommand(args Args, done chan bool) {
 	if len(args.Filenames) <= 0 {
 		for _, asset := range args.ThemeClient.AssetList() {
-			go writeToDisk(args.ThemeClient, asset)
+			if err := writeToDisk(asset); err == nil {
+				client.Message(kit.GreenText(fmt.Sprintf("Successfully wrote %s to disk", filename)))
+			} else {
+				kit.Fatal(err)
+			}
 		}
 	} else {
 		for _, filename := range args.Filenames {
 			if asset, err := args.ThemeClient.Asset(filename); err != nil {
 				if nonFatal, ok := err.(kit.NonFatalNetworkError); ok {
 					args.ThemeClient.Message("[%s] Could not complete %s for %s", kit.RedText(fmt.Sprintf("%d", nonFatal.Code)), kit.YellowText(nonFatal.Verb), kit.BlueText(filename))
+				} else {
+					kit.Fatal(err)
 				}
 			} else {
-				go writeToDisk(args.ThemeClient, asset)
+				if err := writeToDisk(asset); err == nil {
+					client.Message(kit.GreenText(fmt.Sprintf("Successfully wrote %s to disk", filename)))
+				} else {
+					kit.Fatal(err)
+				}
 			}
 		}
 	}
 	done <- true
 }
 
-func writeToDisk(client kit.ThemeClient, asset theme.Asset) {
+func writeToDisk(asset theme.Asset) error {
 	dir, err := os.Getwd()
 	if err != nil {
-		kit.Fatal(err)
-		return
+		return err
 	}
 
 	perms, err := os.Stat(dir)
 	if err != nil {
-		kit.Fatal(err)
-		return
+		return err
 	}
 
 	filename := fmt.Sprintf("%s/%s", dir, asset.Key)
 	err = os.MkdirAll(filepath.Dir(filename), perms.Mode())
 	if err != nil {
-		kit.Fatal(err)
-		return
+		return err
 	}
 
 	file, err := os.Create(filename)
 	if err != nil {
-		kit.Fatal(err)
-		return
+		return err
 	}
 	defer file.Sync()
 	defer file.Close()
@@ -67,8 +73,7 @@ func writeToDisk(client kit.ThemeClient, asset theme.Asset) {
 	case len(asset.Attachment) > 0:
 		data, err = base64.StdEncoding.DecodeString(asset.Attachment)
 		if err != nil {
-			kit.Fatal(fmt.Errorf("Could not decode %s. error: %s", asset.Key, err))
-			return
+			return fmt.Errorf("Could not decode %s. error: %s", asset.Key, err)
 		}
 	}
 
@@ -76,11 +81,7 @@ func writeToDisk(client kit.ThemeClient, asset theme.Asset) {
 		_, err = prettyWrite(file, data)
 	}
 
-	if err != nil {
-		kit.Fatal(err)
-	} else {
-		client.Message(kit.GreenText(fmt.Sprintf("Successfully wrote %s to disk", filename)))
-	}
+	return err
 }
 
 func prettyWrite(file *os.File, data []byte) (n int, err error) {
@@ -92,7 +93,4 @@ func prettyWrite(file *os.File, data []byte) (n int, err error) {
 	default:
 		return file.Write(data)
 	}
-}
-
-func handleError(filename string, err error) {
 }

--- a/commands/download.go
+++ b/commands/download.go
@@ -16,9 +16,7 @@ import (
 func DownloadCommand(args Args, done chan bool) {
 	if len(args.Filenames) <= 0 {
 		for _, asset := range args.ThemeClient.AssetList() {
-			if err := writeToDisk(asset); err == nil {
-				client.Message(kit.GreenText(fmt.Sprintf("Successfully wrote %s to disk", filename)))
-			} else {
+			if err := writeToDisk(args.ThemeClient, asset); err != nil {
 				kit.Fatal(err)
 			}
 		}
@@ -31,9 +29,7 @@ func DownloadCommand(args Args, done chan bool) {
 					kit.Fatal(err)
 				}
 			} else {
-				if err := writeToDisk(asset); err == nil {
-					client.Message(kit.GreenText(fmt.Sprintf("Successfully wrote %s to disk", filename)))
-				} else {
+				if err := writeToDisk(args.ThemeClient, asset); err != nil {
 					kit.Fatal(err)
 				}
 			}
@@ -42,7 +38,7 @@ func DownloadCommand(args Args, done chan bool) {
 	done <- true
 }
 
-func writeToDisk(asset theme.Asset) error {
+func writeToDisk(client kit.ThemeClient, asset theme.Asset) error {
 	dir, err := os.Getwd()
 	if err != nil {
 		return err
@@ -81,7 +77,13 @@ func writeToDisk(asset theme.Asset) error {
 		_, err = prettyWrite(file, data)
 	}
 
-	return err
+	if err != nil {
+		return err
+	}
+
+	client.Message(kit.GreenText(fmt.Sprintf("Successfully wrote %s to disk", filename)))
+
+	return nil
 }
 
 func prettyWrite(file *os.File, data []byte) (n int, err error) {


### PR DESCRIPTION
To make downloads more dependable I have taken out the concurrency since it doesn't really speed it up and only makes download less deterministic. I also added more error logging so I can find errors when they happen.

This may fix https://github.com/Shopify/themekit/issues/221

cc @chrisbutcher @ilikeorangutans 