### PR TITLE
Event filter new approach

### DIFF
--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -189,7 +189,13 @@ of commands that are available, enter the following command into your terminal:<
   <li><code>theme_id</code>: The ID of the theme to upload changes to. <strong>Note</strong> Unlike previous versions of Theme Kit, leaving <code>theme_id</code> blank will no longer default to pointing to your live, production theme. To opt into that behavior, set <code>theme_id</code> to a value of <code>"live"</code></li>
   <li><code>password</code>: API credentials to update and manipulate themes on Shopify</li>
   <li><code>store</code>: Your <code>.myshopify.com</code> domain (i.e. pokeshop.myshopify.com). Note that you <strong>do not</strong> need to include <code>http://</code> or <code>https://</code></li>
-  <li><code>ignore_files</code>: A list of specific files to ignore (i.e. <code>config/settings.html</code>). You can also ignore based on patterns (such as all png files), but those patterns will need to be wrapped in double quotes (i.e. <code>"*.png"</code>).</li>
+  <li><code>ignore_files</code>: A list of specific files to ignore. There are three ways you can specify an ignore
+    <ul>
+      <li>Plain file name from (i.e. <code>config/settings.html</code>, <code>settings.html</code>).</li>
+      <li>Path globbing (i.e. <code>*.png</code>, <code>config/*</code>)</li>
+      <li>You can also ignore based on regex. (i.e. <code>/\.(txt|gif|bat)$/</code>)</li>
+    </ul>
+  </li>
   <li><code>ignores</code>: A list of files containing patterns of files that should be ignored. These files are somewhat similar to the <a href="https://www.kernel.org/pub/software/scm/git/docs/gitignore.html">.gitignore file</a></li>
   <li><code>bucket_size</code>: The size of your Access Tokens bucket. By default this is 40 and cannot be configured by the shop.</li>
   <li><code>refill_rate</code>: The rate at which tickets are replenished by the Shopify API (per second). By default this is 2 and cannot be configured by the shop.</li>

--- a/kit/event_filter.go
+++ b/kit/event_filter.go
@@ -37,6 +37,9 @@ func newEventFilter(rawPatterns []string) eventFilter {
 		if strings.HasPrefix(pattern, "/") && strings.HasSuffix(pattern, "/") {
 			filters = append(filters, regexp.MustCompile(pattern[1:len(pattern)-2]))
 		} else if strings.Contains(pattern, "*") {
+			if !strings.HasPrefix(pattern, "*") {
+				pattern = "*" + pattern
+			}
 			globs = append(globs, pattern)
 		} else { //plain filename
 			globs = append(globs, "*"+pattern)

--- a/kit/event_filter_test.go
+++ b/kit/event_filter_test.go
@@ -8,28 +8,18 @@ import (
 )
 
 func TestEventFilterRejectsEventsThatMatch(t *testing.T) {
-	e := newEventFilter([]string{"foo", "baa*"})
+	e := newEventFilter([]string{"*.bat", "build/*", "*.ini", "config/settings.json"})
 
-	inputEvents := []string{"hello", "foo", "gofoo", "baarber", "barber", "goodbye"}
-	expectedEvents := []string{"hello", "goodbye"}
-	assertFilter(t, e, inputEvents, expectedEvents)
-}
-
-func TestEventFilterTurnsInvalidRegexpsIntoGlobs(t *testing.T) {
-	e := newEventFilter([]string{"*.bat", "build/*", "*.ini"})
-
-	inputEvents := []string{"hello.bat", "build/hello/world", "build/world", "whatever", "foo.ini", "zubat"}
+	inputEvents := []string{"path/to/config/settings.json", "hello.bat", "build/hello/world", "build/world", "whatever", "foo.ini", "zubat"}
 	expectedEvents := []string{"whatever", "zubat"}
 	assertFilter(t, e, inputEvents, expectedEvents)
 }
 
-func TestBuildingEventFiltersFromMultipleReaders(t *testing.T) {
-	e := newEventFilter([]string{"*.bat", "build/", "foo", "bar"})
-	inputEvents := []string{
-		"program.bat", "build/dist/program", "item.liquid", "gofoo", "gobar", "listing", "programbat", "config.yml",
-	}
-	expectedResults := []string{"item.liquid", "listing", "programbat"}
-	assertFilter(t, e, inputEvents, expectedResults)
+func TestFilterFullRegex(t *testing.T) {
+	e := newEventFilter([]string{`/\.(txt|gif|bat)$/`, "config/settings.json", "*.ini"})
+	inputEvents := []string{"path/to/config/settings.json", "hello.bat", "build/hello/world.gif", "build/world.txt", "whatever", "foo.ini", "zubat"}
+	expectedEvents := []string{"whatever", "zubat"}
+	assertFilter(t, e, inputEvents, expectedEvents)
 }
 
 func TestFilterRemovesEmptyStrings(t *testing.T) {
@@ -41,15 +31,14 @@ func TestFilterRemovesEmptyStrings(t *testing.T) {
 
 func TestDefaultFilters(t *testing.T) {
 	e := newEventFilter([]string{})
-	inputEvents := []string{".git/HEAD", ".DS_Store", "config.yml", "templates/products.liquid"}
+	inputEvents := []string{".git/HEAD", ".DS_Store", "templates/.DS_Store", "config.yml", "templates/products.liquid"}
 	expectedEvents := []string{"templates/products.liquid"}
 	assertFilter(t, e, inputEvents, expectedEvents)
 }
 
 func TestMatchesFilterWithEmptyInputDoesNotCrash(t *testing.T) {
 	e := newEventFilter([]string{"config/settings_schema.json", "config/settings_data.json", "*.jpg", "*.png"})
-	// Shouldn't crash
-	e.matchesFilter("")
+	assert.Equal(t, false, e.matchesFilter(""))
 }
 
 func nextValue(channel chan string) string {

--- a/kit/event_filter_test.go
+++ b/kit/event_filter_test.go
@@ -10,7 +10,7 @@ import (
 func TestEventFilterRejectsEventsThatMatch(t *testing.T) {
 	e := newEventFilter([]string{"*.bat", "build/*", "*.ini", "config/settings.json"})
 
-	inputEvents := []string{"path/to/config/settings.json", "hello.bat", "build/hello/world", "build/world", "whatever", "foo.ini", "zubat"}
+	inputEvents := []string{"path/to/config/settings.json", "hello.bat", "total/path/build/hello/world", "build/world", "whatever", "foo.ini", "zubat"}
 	expectedEvents := []string{"whatever", "zubat"}
 	assertFilter(t, e, inputEvents, expectedEvents)
 }

--- a/kit/file_watcher.go
+++ b/kit/file_watcher.go
@@ -57,7 +57,7 @@ func (f fsAssetEvent) String() string {
 }
 
 func newFileWatcher(dir string, recur bool, filter eventFilter) (chan AssetEvent, error) {
-	dirsToWatch, err := findDirectoriesToWatch(dir, recur, filter.MatchesFilter)
+	dirsToWatch, err := findDirectoriesToWatch(dir, recur, filter.matchesFilter)
 	if err != nil {
 		return nil, err
 	}
@@ -153,7 +153,7 @@ func convertFsEvents(events chan fsnotify.Event, filter eventFilter) chan AssetE
 				}
 			case <-time.After(debounceTimeout):
 				for eventName, event := range recordedEvents {
-					if fsevent := handleEvent(event); !filter.MatchesFilter(eventName) && fsevent.IsValid() {
+					if fsevent := handleEvent(event); !filter.matchesFilter(eventName) && fsevent.IsValid() {
 						results <- fsevent
 					}
 				}

--- a/kit/theme_client.go
+++ b/kit/theme_client.go
@@ -156,7 +156,7 @@ func (t ThemeClient) AssetList() []theme.Asset {
 
 	sort.Sort(theme.ByAsset(assets["assets"]))
 
-	return t.filter.FilterAssets(ignoreCompiledAssets(assets["assets"]))
+	return t.filter.filterAssets(ignoreCompiledAssets(assets["assets"]))
 }
 
 // LocalAssets will return a slice of assets from the local disk. The
@@ -164,7 +164,7 @@ func (t ThemeClient) AssetList() []theme.Asset {
 func (t ThemeClient) LocalAssets(dir string) []theme.Asset {
 	dir = fmt.Sprintf("%s%s", dir, string(filepath.Separator))
 
-	assets, err := theme.LoadAssetsFromDirectory(dir, t.filter.MatchesFilter)
+	assets, err := theme.LoadAssetsFromDirectory(dir, t.filter.matchesFilter)
 	if err != nil {
 		Fatal(err)
 	}
@@ -267,7 +267,7 @@ func (t ThemeClient) Process(done chan bool) chan AssetEvent {
 // if it is an update it will post to the server and if it is a remove it will DELETE
 // to the server. Any errors will be outputted to the event log.
 func (t ThemeClient) Perform(asset AssetEvent) {
-	if t.filter.MatchesFilter(asset.Asset().Key) {
+	if t.filter.matchesFilter(asset.Asset().Key) {
 		return
 	}
 


### PR DESCRIPTION
It has become apparent that most people do not need full regex, only globbing so I have rewritten the event filter to reflect this so now this is how it filters. 

- For paths like `config/settings.json` they will be treated like `*config/settings.json` so that they will take effect on the full pwd
- For paths like `*.png` they will be treated like globs
- For paths like `config/* they will be treated like `*config/*` so that they will match the full pwd and anything inside the config directory
- For paths like `/\.(txt|gif|bat)$/` they will be treated like regex (note the begining and ending /)

so you could write your ignore files like this now: 
```
ignore_files:
    - config/settings.json
    - "*.png"
    - /\.(txt|gif|bat)$/ 
```

cc @chrisbutcher @ilikeorangutans 

This could use some long discussion because I am not sure it is the greatest approach. Especially the plain paths. I might make those into regex as well instead of adding a glob to the beginning. Or instead of appending a glob to the begining of any patterns I might just append the pwd so that it would be a plain string comparison.

Let me know what you think. 

**Note**

I might hold off on this and just put it into 0.5.0 since it is kind of breaking. Also in 0.5.0 the directory will be more global (using the directory flag with a default to the pwd) and I will have a better deciding the directory this will effect.