### PR TITLE
Reload watch on config change.

### DIFF
--- a/cmd/theme.go
+++ b/cmd/theme.go
@@ -116,6 +116,7 @@ func generateThemeClients() ([]kit.ThemeClient, error) {
 
 	setFlagConfig()
 
+	configPath, _ = filepath.Abs(configPath)
 	environments, err := kit.LoadEnvironments(configPath)
 	if err != nil {
 		return themeClients, err

--- a/cmd/watch_test.go
+++ b/cmd/watch_test.go
@@ -17,6 +17,9 @@ type WatchTestSuite struct {
 	suite.Suite
 }
 
+func (suite *WatchTestSuite) TestReloadableWatch() {
+}
+
 func (suite *WatchTestSuite) TestWatch() {
 	client, server := newClientAndTestServer(func(w http.ResponseWriter, r *http.Request) {})
 	defer server.Close()
@@ -44,6 +47,16 @@ func (suite *WatchTestSuite) TestHandleWatchEvent() {
 	handleWatchEvent(client, kit.Asset{Key: "templates/layout.liquid"}, kit.Remove, fmt.Errorf("bad watch event"))
 
 	handleWatchEvent(client, kit.Asset{Key: "templates/layout.liquid"}, kit.Remove, nil)
+
+	configPath = "/this/is/config/path.yml"
+	signalChan = make(chan os.Signal, 100)
+
+	handleWatchEvent(client, kit.Asset{Key: configPath}, kit.Update, fmt.Errorf("not in project"))
+	assert.Equal(suite.T(), true, isReloading)
+	assert.Equal(suite.T(), 1, len(signalChan))
+
+	configPath = ""
+	signalChan = make(chan os.Signal)
 
 	assert.Equal(suite.T(), 1, len(requests))
 }

--- a/kit/event_filter.go
+++ b/kit/event_filter.go
@@ -14,7 +14,6 @@ import (
 var defaultRegexes = []*regexp.Regexp{
 	regexp.MustCompile(`\.git/*`),
 	regexp.MustCompile(`\.DS_Store`),
-	regexp.MustCompile(`config.yml`),
 }
 
 var defaultGlobs = []string{}

--- a/kit/event_filter_test.go
+++ b/kit/event_filter_test.go
@@ -92,7 +92,7 @@ func (suite *EventFilterTestSuite) TestMatchesFilter() {
 	if assert.Nil(suite.T(), err) {
 		check(
 			filter,
-			[]string{".git/HEAD", ".DS_Store", "templates/.DS_Store", "config.yml", "templates/products.liquid"},
+			[]string{".git/HEAD", ".DS_Store", "templates/.DS_Store", "templates/products.liquid"},
 			[]string{"templates/products.liquid"},
 		)
 	}

--- a/kit/file_watcher.go
+++ b/kit/file_watcher.go
@@ -133,7 +133,7 @@ func handleEvent(watcher *FileWatcher, event fsnotify.Event) {
 
 	asset.Key = extractAssetKey(event.Name)
 	if asset.Key == "" {
-		err = fmt.Errorf("File not in project workspace.")
+		err = fmt.Errorf("File %s not in project workspace.", event.Name)
 		asset.Key = event.Name
 	}
 

--- a/kit/file_watcher_test.go
+++ b/kit/file_watcher_test.go
@@ -123,7 +123,7 @@ func (suite *FileWatcherTestSuite) TestHandleEvent() {
 
 	watcher := &FileWatcher{callback: func(client ThemeClient, asset Asset, event EventType, err error) {
 		if err != nil {
-			assert.Equal(suite.T(), "File not in project workspace.", err.Error())
+			assert.Equal(suite.T(), "File ../fixtures/project/whatever.txt not in project workspace.", err.Error())
 			assert.Equal(suite.T(), "../fixtures/project/whatever.txt", asset.Key)
 		} else {
 			assert.Equal(suite.T(), extractAssetKey(textFixturePath), asset.Key)

--- a/kit/theme_client_test.go
+++ b/kit/theme_client_test.go
@@ -88,7 +88,7 @@ func (suite *ThemeClientTestSuite) TestAsset() {
 func (suite *ThemeClientTestSuite) TestLocalAssets() {
 	assets, err := suite.client.LocalAssets()
 	assert.Nil(suite.T(), err)
-	assert.Equal(suite.T(), 9, len(assets))
+	assert.Equal(suite.T(), 11, len(assets))
 
 	suite.client.Config.Directory = "./nope"
 	_, err = suite.client.LocalAssets()


### PR DESCRIPTION
fixes #236 

There are instances where users are checking out different branches for different shops but then the watch command would make the changes to the wrong shop.

@chrisbutcher 