### PR TITLE
Changing debounce from single timeout to a timeout for each event.

### DIFF
--- a/kit/file_watcher.go
+++ b/kit/file_watcher.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	debounceTimeout = 1 * time.Second
+	debounceTimeout = 1100 * time.Millisecond
 )
 
 var (
@@ -143,7 +143,7 @@ func handleEvent(watcher *FileWatcher, event fsnotify.Event) {
 
 	asset.Key = extractAssetKey(event.Name)
 	if asset.Key == "" {
-		err = fmt.Errorf("File not in project workspace.")
+		err = fmt.Errorf("File %s is not in project workspace.", event.Name)
 		asset.Key = event.Name
 	}
 

--- a/kit/file_watcher_test.go
+++ b/kit/file_watcher_test.go
@@ -91,7 +91,7 @@ func (suite *FileWatcherTestSuite) TestHandleEvent() {
 
 	watcher := &FileWatcher{callback: func(client ThemeClient, asset Asset, event EventType, err error) {
 		if err != nil {
-			assert.Equal(suite.T(), "File not in project workspace.", err.Error())
+			assert.Equal(suite.T(), "File ../fixtures/project/whatever.txt is not in project workspace.", err.Error())
 			assert.Equal(suite.T(), "../fixtures/project/whatever.txt", asset.Key)
 		} else {
 			assert.Equal(suite.T(), extractAssetKey(textFixturePath), asset.Key)

--- a/kit/file_watcher_test.go
+++ b/kit/file_watcher_test.go
@@ -66,38 +66,6 @@ func (suite *FileWatcherTestSuite) TestConvertFsEvents() {
 	assert.Equal(suite.T(), 2, len(assetChan))
 }
 
-func (suite *FileWatcherTestSuite) TestCallbackEvents() {
-	events := map[string]fsnotify.Event{
-		watchFixturePath + "/templates/template.liquid": {Name: watchFixturePath + "/templates/template.liquid", Op: fsnotify.Write},
-	}
-
-	var wg sync.WaitGroup
-	wg.Add(len(events))
-
-	newWatcher := &FileWatcher{callback: func(client ThemeClient, asset Asset, event EventType, err error) {
-		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), Asset{Key: "templates/template.liquid", Value: ""}, asset)
-		assert.Equal(suite.T(), Update, event)
-		wg.Done()
-	}}
-
-	callbackEvents(newWatcher, events)
-
-	newWatcher = &FileWatcher{callback: func(client ThemeClient, asset Asset, event EventType, err error) {
-		assert.NotNil(suite.T(), err)
-		wg.Done()
-	}}
-
-	events = map[string]fsnotify.Event{
-		"nope/template.liquid": {Name: "nope/template.liquid", Op: fsnotify.Write},
-	}
-	wg.Add(len(events))
-
-	callbackEvents(newWatcher, events)
-
-	wg.Wait()
-}
-
 func (suite *FileWatcherTestSuite) TestStopWatching() {
 	watcher, err := newFileWatcher(ThemeClient{}, watchFixturePath, true, eventFilter{}, func(ThemeClient, Asset, EventType, error) {})
 	assert.Nil(suite.T(), err)


### PR DESCRIPTION
fixes https://github.com/Shopify/themekit/issues/233

There were still problems with the file updating debouncing. I had more of an event loop pattern for my debouncing where it would check all events every second. Now I have moved toward a per event timeout which means each event will be handled one second after the last event on a file was seen. The last seen event will be handled. If this is more of a problem in the future we can provide configuration for the debounce value.

@chrisbutcher 