### PR TITLE
Fixing bad request handling

### DIFF
--- a/kit/http_client.go
+++ b/kit/http_client.go
@@ -105,9 +105,12 @@ func (client *httpClient) GetTheme(themeID int64) (*ShopifyResponse, Error) {
 }
 
 func (client *httpClient) AssetAction(event EventType, asset Asset) (*ShopifyResponse, Error) {
-	resp, _ := client.sendJSON(assetRequest, event, client.AssetPath(), map[string]interface{}{
+	resp, err := client.sendJSON(assetRequest, event, client.AssetPath(), map[string]interface{}{
 		"asset": asset,
 	})
+	if resp == nil {
+		return resp, err
+	}
 	// If there were any errors the asset is nil so lets set it and reformat errors
 	resp.Asset = asset
 	return resp, resp.Error()

--- a/kit/http_client.go
+++ b/kit/http_client.go
@@ -105,21 +105,18 @@ func (client *httpClient) GetTheme(themeID int64) (*ShopifyResponse, Error) {
 }
 
 func (client *httpClient) AssetAction(event EventType, asset Asset) (*ShopifyResponse, Error) {
-	resp, err := client.sendJSON(assetRequest, event, client.AssetPath(), map[string]interface{}{
+	resp, _ := client.sendJSON(assetRequest, event, client.AssetPath(), map[string]interface{}{
 		"asset": asset,
 	})
-	if resp == nil {
-		return resp, err
-	}
 	// If there were any errors the asset is nil so lets set it and reformat errors
 	resp.Asset = asset
 	return resp, resp.Error()
 }
 
-func (client *httpClient) newRequest(event EventType, urlStr string, body io.Reader) (*http.Request, Error) {
+func (client *httpClient) newRequest(event EventType, urlStr string, body io.Reader) (*http.Request, error) {
 	req, err := http.NewRequest(event.toMethod(), urlStr, body)
 	if err != nil {
-		return nil, kitError{err}
+		return nil, err
 	}
 
 	req.Header.Add("X-Shopify-Access-Token", client.config.Password)
@@ -133,7 +130,7 @@ func (client *httpClient) newRequest(event EventType, urlStr string, body io.Rea
 func (client *httpClient) sendJSON(rtype requestType, event EventType, urlStr string, body map[string]interface{}) (*ShopifyResponse, Error) {
 	data, err := json.Marshal(body)
 	if err != nil {
-		return nil, kitError{err}
+		return newShopifyResponse(rtype, event, nil, err)
 	}
 	return client.sendRequest(rtype, event, urlStr, bytes.NewBuffer(data))
 }
@@ -141,7 +138,7 @@ func (client *httpClient) sendJSON(rtype requestType, event EventType, urlStr st
 func (client *httpClient) sendRequest(rtype requestType, event EventType, urlStr string, body io.Reader) (*ShopifyResponse, Error) {
 	req, err := client.newRequest(event, urlStr, body)
 	if err != nil {
-		return nil, kitError{err}
+		return newShopifyResponse(rtype, event, nil, err)
 	}
 	apiLimit.Wait()
 	resp, respErr := client.client.Do(req)

--- a/kit/shopify_response.go
+++ b/kit/shopify_response.go
@@ -27,7 +27,10 @@ type ShopifyResponse struct {
 
 func newShopifyResponse(rtype requestType, event EventType, resp *http.Response, err error) (*ShopifyResponse, Error) {
 	if resp == nil || err != nil {
-		return nil, kitError{err}
+		return &ShopifyResponse{
+			Type:      rtype,
+			EventType: event,
+		}, kitError{err}
 	}
 	defer resp.Body.Close()
 
@@ -41,7 +44,7 @@ func newShopifyResponse(rtype requestType, event EventType, resp *http.Response,
 
 	bytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return nil, kitError{err}
+		return newResponse, kitError{err}
 	}
 
 	err = json.Unmarshal(bytes, &newResponse)

--- a/kit/shopify_response_test.go
+++ b/kit/shopify_response_test.go
@@ -18,7 +18,7 @@ func (suite *ShopifyResponseTestSuite) TestRequestError() {
 	errorMessage := "something went wrong"
 	badErr := fmt.Errorf(errorMessage)
 	resp, err := newShopifyResponse(themeRequest, Create, &http.Response{}, badErr)
-	assert.Nil(suite.T(), resp)
+	assert.NotNil(suite.T(), resp)
 	if assert.NotNil(suite.T(), err) {
 		assert.Equal(suite.T(), errorMessage, err.Error())
 	}
@@ -31,7 +31,7 @@ func (suite *ShopifyResponseTestSuite) TestNoBody() {
 	}
 	mock.Body.Close()
 	resp, err := newShopifyResponse(themeRequest, Create, mock, nil)
-	assert.Nil(suite.T(), resp)
+	assert.NotNil(suite.T(), resp)
 	assert.NotNil(suite.T(), err)
 }
 


### PR DESCRIPTION
fixes #246 

lIn asset events, after the request is finished theme kit would set some values on the response to generate better errors, however if the request never completed successfully then the response would not exists and the program would panic. I added catching for that so that the error will be logged and the application will not panic.