### PR TITLE
Fixing create errors and bad error messages.

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -6,7 +6,7 @@ baseurl: "/themekit"
 url: "https://shopify.github.io"
 sass:
   cache: true
-themekitversion: "v0.5.1"
+themekitversion: "v0.5.2"
 
 # Build settings
 markdown: kramdown

--- a/kit/errors.go
+++ b/kit/errors.go
@@ -151,3 +151,9 @@ func (err *requestError) AddS(other string) {
 		err.Other = append(err.Other, other)
 	}
 }
+
+func (err *requestError) AddE(other error) {
+	if other != nil {
+		err.Other = append(err.Other, other.Error())
+	}
+}

--- a/kit/file_watcher.go
+++ b/kit/file_watcher.go
@@ -124,13 +124,8 @@ func (watcher *FileWatcher) StopWatching() {
 }
 
 func handleEvent(watcher *FileWatcher, event fsnotify.Event) {
-	var eventType EventType
-	var err error
-
-	switch event.Op {
-	case fsnotify.Chmod, fsnotify.Create, fsnotify.Write:
-		eventType = Update
-	case fsnotify.Remove:
+	eventType := Update
+	if event.Op&fsnotify.Remove == fsnotify.Remove {
 		eventType = Remove
 	}
 
@@ -141,6 +136,7 @@ func handleEvent(watcher *FileWatcher, event fsnotify.Event) {
 		asset = Asset{}
 	}
 
+	var err error
 	asset.Key = extractAssetKey(event.Name)
 	if asset.Key == "" {
 		err = fmt.Errorf("File %s is not in project workspace.", event.Name)

--- a/kit/http_client.go
+++ b/kit/http_client.go
@@ -130,7 +130,7 @@ func (client *httpClient) newRequest(event EventType, urlStr string, body io.Rea
 func (client *httpClient) sendJSON(rtype requestType, event EventType, urlStr string, body map[string]interface{}) (*ShopifyResponse, Error) {
 	data, err := json.Marshal(body)
 	if err != nil {
-		return newShopifyResponse(rtype, event, nil, err)
+		return newShopifyResponse(rtype, event, urlStr, nil, err)
 	}
 	return client.sendRequest(rtype, event, urlStr, bytes.NewBuffer(data))
 }
@@ -138,9 +138,9 @@ func (client *httpClient) sendJSON(rtype requestType, event EventType, urlStr st
 func (client *httpClient) sendRequest(rtype requestType, event EventType, urlStr string, body io.Reader) (*ShopifyResponse, Error) {
 	req, err := client.newRequest(event, urlStr, body)
 	if err != nil {
-		return newShopifyResponse(rtype, event, nil, err)
+		return newShopifyResponse(rtype, event, urlStr, nil, err)
 	}
 	apiLimit.Wait()
 	resp, respErr := client.client.Do(req)
-	return newShopifyResponse(rtype, event, resp, respErr)
+	return newShopifyResponse(rtype, event, urlStr, resp, respErr)
 }

--- a/kit/shopify_response.go
+++ b/kit/shopify_response.go
@@ -26,20 +26,18 @@ type ShopifyResponse struct {
 }
 
 func newShopifyResponse(rtype requestType, event EventType, requestURL string, resp *http.Response, err error) (*ShopifyResponse, Error) {
-	parsedUrl, _ := url.Parse(requestURL)
+	parsedURL, _ := url.Parse(requestURL)
 
 	newResponse := &ShopifyResponse{
 		Type:      rtype,
 		EventType: event,
-		Host:      parsedUrl.Host,
-		URL:       parsedUrl,
+		Host:      parsedURL.Host,
+		URL:       parsedURL,
 	}
 	newResponse.Errors.AddE(err)
 
 	if resp != nil {
 		defer resp.Body.Close()
-		newResponse.Host = resp.Request.URL.Host
-		newResponse.URL = resp.Request.URL
 		newResponse.Code = resp.StatusCode
 
 		bytes, err := ioutil.ReadAll(resp.Body)

--- a/kit/shopify_response_test.go
+++ b/kit/shopify_response_test.go
@@ -17,11 +17,9 @@ type ShopifyResponseTestSuite struct {
 func (suite *ShopifyResponseTestSuite) TestRequestError() {
 	errorMessage := "something went wrong"
 	badErr := fmt.Errorf(errorMessage)
-	resp, err := newShopifyResponse(themeRequest, Create, &http.Response{}, badErr)
+	resp, err := newShopifyResponse(themeRequest, Create, "", nil, badErr)
 	assert.NotNil(suite.T(), resp)
-	if assert.NotNil(suite.T(), err) {
-		assert.Equal(suite.T(), errorMessage, err.Error())
-	}
+	assert.NotNil(suite.T(), err)
 }
 
 func (suite *ShopifyResponseTestSuite) TestNoBody() {
@@ -30,7 +28,7 @@ func (suite *ShopifyResponseTestSuite) TestNoBody() {
 		Body:    fileFixture("responses/general_error"),
 	}
 	mock.Body.Close()
-	resp, err := newShopifyResponse(themeRequest, Create, mock, nil)
+	resp, err := newShopifyResponse(themeRequest, Create, "", mock, nil)
 	assert.NotNil(suite.T(), resp)
 	assert.NotNil(suite.T(), err)
 }
@@ -104,7 +102,7 @@ func (suite *ShopifyResponseTestSuite) TestError() {
 }
 
 func (suite *ShopifyResponseTestSuite) shopifyResp(path string) (*ShopifyResponse, Error) {
-	return newShopifyResponse(themeRequest, Create, suite.respFixture(path), nil)
+	return newShopifyResponse(themeRequest, Create, "", suite.respFixture(path), nil)
 }
 
 func (suite *ShopifyResponseTestSuite) respFixture(path string) *http.Response {

--- a/kit/version.go
+++ b/kit/version.go
@@ -14,7 +14,7 @@ import (
 
 var (
 	// ThemeKitVersion is the version build of the library
-	ThemeKitVersion, _ = version.NewVersion("0.5.1")
+	ThemeKitVersion, _ = version.NewVersion("0.5.2")
 	releasesURL        = "https://shopify-themekit.s3.amazonaws.com/releases/all.json"
 )
 


### PR DESCRIPTION
fixes #249 

There was an issue where update events had many ops in the the `event.Op` field so when the event was interpreted the event type was missed and the default event `Create` was set. This caused a 404. 

Also I had noticed that some errors mentioned by @chryton had very poor error reporting. This has also been fixed.