### PR TITLE
Changed how configuration is used

### DIFF
--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -26,7 +26,7 @@ For more documentation please see http://shopify.github.io/themekit/commands/#co
 	},
 }
 
-func saveConfiguration(config kit.Configuration) error {
+func saveConfiguration(config *kit.Configuration) error {
 	env, err := kit.LoadEnvironments(configPath)
 	if err != nil && !os.IsNotExist(err) {
 		return err

--- a/cmd/theme.go
+++ b/cmd/theme.go
@@ -126,7 +126,7 @@ func generateThemeClients() ([]kit.ThemeClient, error) {
 		if err != nil {
 			return themeClients, err
 		}
-		environments = map[string]kit.Configuration{environment: config}
+		environments = map[string]*kit.Configuration{environment: config}
 	}
 
 	for env := range environments {

--- a/kit/configuration.go
+++ b/kit/configuration.go
@@ -55,16 +55,16 @@ func SetFlagConfig(config Configuration) {
 // flags. Then it will validate that config. It will return the
 // formatted configuration along with any validation errors. The config precedence
 // is flags, environment variables, then the config file.
-func NewConfiguration() (Configuration, error) {
-	return Configuration{}.compile()
+func NewConfiguration() (*Configuration, error) {
+	return (&Configuration{}).compile()
 }
 
-func (conf Configuration) compile() (Configuration, error) {
-	newConfig := Configuration{}
-	mergo.Merge(&newConfig, &flagConfig)
-	mergo.Merge(&newConfig, &environmentConfig)
-	mergo.Merge(&newConfig, &conf)
-	mergo.Merge(&newConfig, &defaultConfig)
+func (conf *Configuration) compile() (*Configuration, error) {
+	newConfig := &Configuration{}
+	mergo.Merge(newConfig, &flagConfig)
+	mergo.Merge(newConfig, &environmentConfig)
+	mergo.Merge(newConfig, conf)
+	mergo.Merge(newConfig, &defaultConfig)
 	return newConfig, newConfig.Validate()
 }
 
@@ -95,11 +95,11 @@ func (conf Configuration) validateNoThemeID() error {
 	errors := []string{}
 
 	if len(conf.Domain) == 0 {
-		errors = append(errors, "missing domain")
+		errors = append(errors, "missing store domain")
 	} else if !strings.HasSuffix(conf.Domain, "myshopify.com") &&
 		!strings.HasSuffix(conf.Domain, "myshopify.io") &&
 		!strings.HasPrefix(conf.Domain, "http://127.0.0.1:") {
-		errors = append(errors, "invalid domain must end in '.myshopify.com'")
+		errors = append(errors, "invalid store domain must end in '.myshopify.com'")
 	}
 
 	if len(conf.Password) == 0 {

--- a/kit/configuration_test.go
+++ b/kit/configuration_test.go
@@ -20,7 +20,7 @@ func (suite *ConfigurationTestSuite) TearDownTest() {
 
 func (suite *ConfigurationTestSuite) TestSetFlagConfig() {
 	config, _ := NewConfiguration()
-	assert.Equal(suite.T(), defaultConfig, config)
+	assert.Equal(suite.T(), defaultConfig, *config)
 
 	flagConfig := Configuration{
 		Directory: "my/dir/now",
@@ -29,12 +29,12 @@ func (suite *ConfigurationTestSuite) TestSetFlagConfig() {
 	SetFlagConfig(flagConfig)
 
 	config, _ = NewConfiguration()
-	assert.Equal(suite.T(), flagConfig, config)
+	assert.Equal(suite.T(), flagConfig, *config)
 }
 
 func (suite *ConfigurationTestSuite) TestEnvConfig() {
 	config, _ := NewConfiguration()
-	assert.Equal(suite.T(), defaultConfig, config)
+	assert.Equal(suite.T(), defaultConfig, *config)
 
 	environmentConfig = Configuration{
 		Password:     "password",
@@ -48,11 +48,11 @@ func (suite *ConfigurationTestSuite) TestEnvConfig() {
 	}
 
 	config, _ = NewConfiguration()
-	assert.Equal(suite.T(), environmentConfig, config)
+	assert.Equal(suite.T(), environmentConfig, *config)
 }
 
 func (suite *ConfigurationTestSuite) TestConfigPrecedence() {
-	config := Configuration{Password: "file"}
+	config := &Configuration{Password: "file"}
 	config, _ = config.compile()
 	assert.Equal(suite.T(), "file", config.Password)
 
@@ -81,13 +81,13 @@ func (suite *ConfigurationTestSuite) TestValidate() {
 	config = Configuration{Password: "test", ThemeID: "123", Domain: "test.nope.com"}
 	err = config.Validate()
 	if assert.NotNil(suite.T(), err) {
-		assert.Equal(suite.T(), true, strings.Contains(err.Error(), "invalid domain"))
+		assert.Equal(suite.T(), true, strings.Contains(err.Error(), "invalid store domain"))
 	}
 
 	config = Configuration{Password: "test", ThemeID: "123"}
 	err = config.Validate()
 	if assert.NotNil(suite.T(), err) {
-		assert.Equal(suite.T(), true, strings.Contains(err.Error(), "missing domain"))
+		assert.Equal(suite.T(), true, strings.Contains(err.Error(), "missing store domain"))
 	}
 
 	config = Configuration{Password: "file", Domain: "test.myshopify.com"}

--- a/kit/environments.go
+++ b/kit/environments.go
@@ -12,12 +12,12 @@ import (
 const DefaultEnvironment string = "development"
 
 // Environments is a map of configurations to their environment name.
-type Environments map[string]Configuration
+type Environments map[string]*Configuration
 
 // LoadEnvironments will read in the file from the location provided and
 // then unmarshal the data into environments.
 func LoadEnvironments(location string) (env Environments, err error) {
-	env = map[string]Configuration{}
+	env = map[string]*Configuration{}
 	contents, err := ioutil.ReadFile(location)
 	if err == nil {
 		err = yaml.Unmarshal(contents, &env)
@@ -26,13 +26,13 @@ func LoadEnvironments(location string) (env Environments, err error) {
 }
 
 // SetConfiguration will update a config environment to the provided configuration.
-func (e Environments) SetConfiguration(environmentName string, conf Configuration) {
+func (e Environments) SetConfiguration(environmentName string, conf *Configuration) {
 	e[environmentName] = conf
 }
 
 // GetConfiguration will return the configuration for the environment. An error will
 // be returned if the environment does not exist or the configuration is invalid.
-func (e Environments) GetConfiguration(environmentName string) (Configuration, error) {
+func (e Environments) GetConfiguration(environmentName string) (*Configuration, error) {
 	conf, exists := e[environmentName]
 	if !exists {
 		return conf, fmt.Errorf("%s does not exist in this environments list", environmentName)

--- a/kit/http_client.go
+++ b/kit/http_client.go
@@ -18,7 +18,7 @@ var apiLimit = newRateLimiter(time.Second / 2)
 
 type httpClient struct {
 	client *http.Client
-	config Configuration
+	config *Configuration
 }
 
 type requestType int
@@ -29,7 +29,7 @@ const (
 	listRequest
 )
 
-func newHTTPClient(config Configuration) (*httpClient, error) {
+func newHTTPClient(config *Configuration) (*httpClient, error) {
 	client := &httpClient{
 		client: &http.Client{Timeout: config.Timeout},
 		config: config,

--- a/kit/http_client_test.go
+++ b/kit/http_client_test.go
@@ -18,7 +18,7 @@ import (
 
 type HTTPClientTestSuite struct {
 	suite.Suite
-	config Configuration
+	config *Configuration
 	client *httpClient
 }
 

--- a/kit/theme_client.go
+++ b/kit/theme_client.go
@@ -13,7 +13,7 @@ const createThemeMaxRetries int = 3
 // ThemeClient is the interactor with the shopify server. All actions are processed
 // with the client.
 type ThemeClient struct {
-	Config     Configuration
+	Config     *Configuration
 	httpClient *httpClient
 	filter     eventFilter
 }
@@ -21,7 +21,7 @@ type ThemeClient struct {
 // NewThemeClient will build a new theme client from a configuration and a theme event
 // channel. The channel is used for logging all events. The configuration specifies how
 // the client will behave.
-func NewThemeClient(config Configuration) (ThemeClient, error) {
+func NewThemeClient(config *Configuration) (ThemeClient, error) {
 	httpClient, err := newHTTPClient(config)
 	if err != nil {
 		return ThemeClient{}, err
@@ -121,7 +121,7 @@ func CreateTheme(name, zipLocation string) (ThemeClient, Theme, error) {
 
 	client.Config.ThemeID = fmt.Sprintf("%d", resp.Theme.ID)
 
-	return client, theme, nil
+	return client, theme, err
 }
 
 // CreateAsset will take an asset and will return  when the asset has been created.

--- a/kit/theme_client_test.go
+++ b/kit/theme_client_test.go
@@ -15,7 +15,7 @@ import (
 
 type ThemeClientTestSuite struct {
 	suite.Suite
-	config Configuration
+	config *Configuration
 	client ThemeClient
 }
 
@@ -122,18 +122,18 @@ func (suite *ThemeClientTestSuite) TestCreateTheme() {
 
 	client, theme, err := CreateTheme("name", "source")
 	if assert.NotNil(suite.T(), err) {
-		assert.Equal(suite.T(), "Invalid options: missing domain,missing password", err.Error())
+		assert.Equal(suite.T(), "Invalid options: missing store domain,missing password", err.Error())
 	}
 
 	suite.config.Ignores = []string{"nope"}
-	SetFlagConfig(suite.config)
+	SetFlagConfig(*suite.config)
 	client, theme, err = CreateTheme("name", "source")
 	assert.NotNil(suite.T(), err)
 
 	suite.config.Ignores = []string{}
 	suite.config.Domain = server.URL
 
-	SetFlagConfig(suite.config)
+	SetFlagConfig(*suite.config)
 	client, theme, err = CreateTheme("name", "source")
 	if assert.NotNil(suite.T(), err) {
 		assert.Equal(suite.T(), true, strings.Contains(err.Error(), "Cannot create a theme. Last error was"))


### PR DESCRIPTION
fixes https://github.com/Shopify/themekit/issues/248

The configuration is now accessed as a pointer rather than value so when it is changed in one place, all other references to the same config will have those changes. It probably should have been a pointer before anyways since it is the most passed around object.

@chrisbutcher 