### PR TITLE
Adding more file ignores and ignoring the main directory from watcher

### DIFF
--- a/kit/event_filter.go
+++ b/kit/event_filter.go
@@ -12,8 +12,17 @@ import (
 )
 
 var defaultRegexes = []*regexp.Regexp{
-	regexp.MustCompile(`\.git/*`),
+	regexp.MustCompile(`\.git`),
+	regexp.MustCompile(`\.hg`),
+	regexp.MustCompile(`\.bzr`),
+	regexp.MustCompile(`\.svn`),
+	regexp.MustCompile(`_darcs`),
+	regexp.MustCompile(`CVS`),
+	regexp.MustCompile(`\.sublime-(project|workspace)`),
 	regexp.MustCompile(`\.DS_Store`),
+	regexp.MustCompile(`\.sass-cache`),
+	regexp.MustCompile(`Thumbs\.db`),
+	regexp.MustCompile(`desktop\.ini`),
 	regexp.MustCompile(`config.yml`),
 }
 

--- a/kit/file_watcher_test.go
+++ b/kit/file_watcher_test.go
@@ -46,7 +46,7 @@ func (suite *FileWatcherTestSuite) TestConvertFsEvents() {
 		wg.Done()
 	}
 
-	go convertFsEvents(newWatcher)
+	go newWatcher.convertFsEvents()
 
 	go func() {
 		writes := []fsnotify.Event{
@@ -121,25 +121,6 @@ func (suite *FileWatcherTestSuite) TestExtractAssetKey() {
 	for input, expected := range tests {
 		assert.Equal(suite.T(), expected, extractAssetKey(input))
 	}
-}
-
-func (suite *FileWatcherTestSuite) TestfindDirectoriesToWatch() {
-	expected := []string{
-		clean(watchFixturePath),
-		clean(watchFixturePath + "/assets"),
-		clean(watchFixturePath + "/config"),
-		clean(watchFixturePath + "/layout"),
-		clean(watchFixturePath + "/locales"),
-		clean(watchFixturePath + "/snippets"),
-		clean(watchFixturePath + "/templates"),
-		clean(watchFixturePath + "/templates/customers"),
-	}
-
-	files := findDirectoriesToWatch(watchFixturePath, true, func(string) bool { return false })
-	assert.Equal(suite.T(), expected, files)
-
-	files = findDirectoriesToWatch(watchFixturePath, false, func(string) bool { return false })
-	assert.Equal(suite.T(), []string{clean(watchFixturePath)}, files)
 }
 
 func TestFileWatcherTestSuite(t *testing.T) {


### PR DESCRIPTION
fixes #251

Also mitigates #253

Some users are having some problems with OSX's low file descriptor limit. I cannot just simply make the file watcher only watch valid files and not the directories because that will drop created events. I believe that by ignoring the root directory we will miss a lot of application/VCS/processor data. The main side effect of this may be that if the user creates a new folder (sections for instance) it will not get picked up.

@chrisbutcher Any thoughts on if this will effect anything else?