### PR TITLE
Made more strict checking for test domains

### DIFF
--- a/kit/configuration.go
+++ b/kit/configuration.go
@@ -99,7 +99,7 @@ func (conf Configuration) validateNoThemeID() error {
 		errors = append(errors, "missing store domain")
 	} else if !strings.HasSuffix(conf.Domain, "myshopify.com") &&
 		!strings.HasSuffix(conf.Domain, "myshopify.io") &&
-		!strings.HasPrefix(conf.Domain, "http://127.0.0.1:") {
+		!strings.HasPrefix(conf.Domain, "http://127.0.0.1:") { // for testing
 		errors = append(errors, "invalid store domain must end in '.myshopify.com'")
 	}
 

--- a/kit/http_client.go
+++ b/kit/http_client.go
@@ -61,7 +61,8 @@ func (client *httpClient) AdminURL() string {
 	}
 	parsedURL, _ := url.Parse(adminURL)
 	parsedURL.Scheme = "https"
-	if strings.HasPrefix(client.config.Domain, "http") {
+	// for testing, because otherwise the domain should not be localhost or http
+	if strings.HasPrefix(client.config.Domain, "http://127.0.0.1:") {
 		parsedURL.Scheme = "http"
 	}
 	return parsedURL.String()


### PR DESCRIPTION
There was an issue recently #262 where the user had specified `http://` before thier store domain and since I allowed http urls for testing, it was a valid config. This resulted in shopify responding with 403 because ssl is required. So to allow testing to stay easy but also default to ssl for normal use cases I have just added better prefix checking on the domain. 

@chrisbutcher 