### PR TITLE
Adding back in the notify file functionality

### DIFF
--- a/kit/file_watcher_test.go
+++ b/kit/file_watcher_test.go
@@ -1,7 +1,6 @@
 package kit
 
 import (
-	"os"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -65,30 +64,6 @@ func (suite *FileWatcherTestSuite) TestWatchFsEvents() {
 	wg.Wait()
 	// test that the events are debounced
 	assert.Equal(suite.T(), 2, len(assetChan))
-}
-
-func (suite *FileWatcherTestSuite) TestNotifyFile() {
-	eventChan := make(chan fsnotify.Event)
-	var wg sync.WaitGroup
-	wg.Add(2)
-
-	newWatcher := &FileWatcher{
-		done:    make(chan bool),
-		watcher: &fsnotify.Watcher{Events: eventChan},
-	}
-
-	notePath := watchFixturePath + "/note"
-
-	go newWatcher.watchFsEvents(notePath)
-
-	time.Sleep(2 * time.Second)
-
-	close(eventChan)
-
-	_, err := os.Stat(notePath)
-	assert.Nil(suite.T(), err)
-	err = os.Remove(notePath)
-	assert.Nil(suite.T(), err)
 }
 
 func (suite *FileWatcherTestSuite) TestStopWatching() {

--- a/kit/theme_client.go
+++ b/kit/theme_client.go
@@ -43,7 +43,7 @@ func NewThemeClient(config *Configuration) (ThemeClient, error) {
 
 // NewFileWatcher creates a new filewatcher using the theme clients file filter
 func (t ThemeClient) NewFileWatcher(notifyFile string, callback FileEventCallback) (*FileWatcher, error) {
-	return newFileWatcher(t, t.Config.Directory, true, t.filter, callback)
+	return newFileWatcher(t, t.Config.Directory, notifyFile, true, t.filter, callback)
 }
 
 // AssetList will return a slice of remote assets from the shopify servers. The


### PR DESCRIPTION
fixes #267 

In the last refactor, the notify file functionality was accidentally removed. This PR adds it back in. It will touch the file, update the file's access and modify times whenever there are no fs events in the queue after one second.

@chrisbutcher 