### PR TITLE
Allowing directory config to come from the config file

### DIFF
--- a/fixtures/project/valid_config.yml
+++ b/fixtures/project/valid_config.yml
@@ -6,7 +6,6 @@ default:
   - charmander
   - bulbasaur
   - squirtle
-  timeout: 30s
 development:
   password: abracadabra
   theme_id: "1"

--- a/kit/configuration.go
+++ b/kit/configuration.go
@@ -18,7 +18,7 @@ type Configuration struct {
 	Password     string        `yaml:"password,omitempty" json:"password,omitempty" env:"THEMEKIT_PASSWORD"`
 	ThemeID      string        `yaml:"theme_id,omitempty" json:"theme_id,omitempty" env:"THEMEKIT_THEME_ID"`
 	Domain       string        `yaml:"store" json:"store" env:"THEMEKIT_STORE"`
-	Directory    string        `yaml:"-" json:"-" env:"THEMEKIT_DIRECTORY"`
+	Directory    string        `yaml:"directory,omitempty" json:"directory" env:"THEMEKIT_DIRECTORY"`
 	IgnoredFiles []string      `yaml:"ignore_files,omitempty" json:"ignore_files,omitempty" env:"THEMEKIT_IGNORE_FILES" envSeparator:":"`
 	Proxy        string        `yaml:"proxy,omitempty" json:"proxy,omitempty" env:"THEMEKIT_PROXY"`
 	Ignores      []string      `yaml:"ignores,omitempty" json:"ignores,omitempty" env:"THEMEKIT_IGNORES" envSeparator:":"`
@@ -138,4 +138,14 @@ Timeout      %v
 		conf.Proxy,
 		conf.Ignores,
 		conf.Timeout)
+}
+
+func (conf Configuration) asYAML() *Configuration {
+	if conf.Directory == defaultConfig.Directory {
+		conf.Directory = ""
+	}
+	if conf.Timeout == defaultConfig.Timeout {
+		conf.Timeout = 0
+	}
+	return &conf
 }

--- a/kit/configuration.go
+++ b/kit/configuration.go
@@ -18,7 +18,7 @@ type Configuration struct {
 	Password     string        `yaml:"password,omitempty" json:"password,omitempty" env:"THEMEKIT_PASSWORD"`
 	ThemeID      string        `yaml:"theme_id,omitempty" json:"theme_id,omitempty" env:"THEMEKIT_THEME_ID"`
 	Domain       string        `yaml:"store" json:"store" env:"THEMEKIT_STORE"`
-	Directory    string        `yaml:"directory,omitempty" json:"directory" env:"THEMEKIT_DIRECTORY"`
+	Directory    string        `yaml:"directory,omitempty" json:"directory,omitempty" env:"THEMEKIT_DIRECTORY"`
 	IgnoredFiles []string      `yaml:"ignore_files,omitempty" json:"ignore_files,omitempty" env:"THEMEKIT_IGNORE_FILES" envSeparator:":"`
 	Proxy        string        `yaml:"proxy,omitempty" json:"proxy,omitempty" env:"THEMEKIT_PROXY"`
 	Ignores      []string      `yaml:"ignores,omitempty" json:"ignores,omitempty" env:"THEMEKIT_IGNORES" envSeparator:":"`

--- a/kit/environments.go
+++ b/kit/environments.go
@@ -74,10 +74,18 @@ func (e Environments) Save(location string) error {
 	defer file.Close()
 	if err == nil {
 		var bytes []byte
-		bytes, err = yaml.Marshal(e)
+		bytes, err = yaml.Marshal(e.asYAML())
 		if err == nil {
 			_, err = file.Write(bytes)
 		}
 	}
 	return err
+}
+
+func (e Environments) asYAML() Environments {
+	out := map[string]*Configuration{}
+	for name, config := range e {
+		out[name] = config.asYAML()
+	}
+	return out
 }


### PR DESCRIPTION
fixes #268 

The directory config in the config file was not properly respected. This adds in support for that config as well as filtering out default values from marshalling into new config.yml files.

@chrisbutcher 