### PR TITLE
Logging work

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -90,7 +90,7 @@ func writeToDisk(directory string, asset kit.Asset) error {
 		return err
 	}
 
-	kit.LogNotifyf("Successfully wrote %s to disk", filename)
+	kit.Print(kit.GreenText("Successfully wrote %s to disk", filename))
 	return nil
 }
 

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -90,7 +90,7 @@ func writeToDisk(directory string, asset kit.Asset) error {
 		return err
 	}
 
-	kit.Print(kit.GreenText("Successfully wrote %s to disk", filename))
+	kit.Print(kit.GreenText(fmt.Sprintf("Successfully wrote %s to disk", filename)))
 	return nil
 }
 

--- a/cmd/theme.go
+++ b/cmd/theme.go
@@ -112,7 +112,7 @@ func generateThemeClients() ([]kit.ThemeClient, error) {
 	themeClients := []kit.ThemeClient{}
 
 	if !noUpdateNotifier && kit.IsNewUpdateAvailable() {
-		kit.LogWarn(updateAvailableMessage)
+		kit.Print(kit.YellowText(updateAvailableMessage))
 	}
 
 	setFlagConfig()

--- a/cmd/theme/setup_darwin.go
+++ b/cmd/theme/setup_darwin.go
@@ -20,7 +20,7 @@ func init() {
 	}
 	rLimit.Cur = uint64(math.Max(minFileDescriptors, float64(rLimit.Cur)))
 	if err := syscall.Setrlimit(syscall.RLIMIT_NOFILE, &rLimit); err != nil {
-		kit.LogWarnf("%s\n", err)
-		kit.LogWarnf("Could not set file descriptor limits. Themekit will work, but you might encounter issues if your project holds many files. You can set the limits manually using ulimit -n 2048.\n")
+		kit.Print(err)
+		kit.Print(kit.YellowText("Could not set file descriptor limits. Themekit will work, but you might encounter issues if your project holds many files. You can set the limits manually using ulimit -n 2048."))
 	}
 }

--- a/kit/http_client.go
+++ b/kit/http_client.go
@@ -36,8 +36,8 @@ func newHTTPClient(config *Configuration) (*httpClient, error) {
 	}
 
 	if len(config.Proxy) > 0 {
-		LogWarnf("Proxy URL detected from Configuration: %s", config.Proxy)
-		LogWarn("SSL Certificate Validation will be disabled!")
+		Print(YellowText("Proxy URL detected from Configuration: %s", config.Proxy))
+		Print(YellowText("SSL Certificate Validation will be disabled!"))
 		proxyURL, err := url.Parse(config.Proxy)
 		if err != nil {
 			return client, err

--- a/kit/http_client.go
+++ b/kit/http_client.go
@@ -36,7 +36,7 @@ func newHTTPClient(config *Configuration) (*httpClient, error) {
 	}
 
 	if len(config.Proxy) > 0 {
-		Print(YellowText("Proxy URL detected from Configuration: %s", config.Proxy))
+		Print(YellowText(fmt.Sprintf("Proxy URL detected from Configuration: %s", config.Proxy)))
 		Print(YellowText("SSL Certificate Validation will be disabled!"))
 		proxyURL, err := url.Parse(config.Proxy)
 		if err != nil {

--- a/kit/logging.go
+++ b/kit/logging.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"time"
 
 	"github.com/fatih/color"
 )
@@ -24,61 +25,51 @@ var BlueText = color.New(color.FgBlue).SprintFunc()
 // green when printed out.
 var GreenText = color.New(color.FgGreen).SprintFunc()
 
+// CyanText is a func that wraps a string in cyan color tags and it will be
+// cyan when printed out.
+var CyanText = color.New(color.FgCyan).SprintFunc()
+
+const timestampFormat = "15:04:05"
+
 func init() {
 	log.SetFlags(0)
 	log.SetOutput(os.Stderr)
 }
 
+func timestamp() string {
+	return CyanText(time.Now().Format(timestampFormat)) + " "
+}
+
 // Printf will output a formatted message to the output log (default stdout)
 func Printf(content string, args ...interface{}) {
-	fmt.Println(fmt.Sprintf(content, args...))
+	fmt.Println(timestamp() + fmt.Sprintf(content, args...))
 }
 
 // Print will output a message to the output log (default stdout)
 func Print(args ...interface{}) {
-	fmt.Println(args...)
-}
-
-// LogNotifyf will output a formatted green message to the output log (default stdout)
-func LogNotifyf(content string, args ...interface{}) {
-	fmt.Println(GreenText(fmt.Sprintf(content, args...)))
-}
-
-// LogNotify will output a green message to the output log (default stdout)
-func LogNotify(args ...interface{}) {
-	log.Println(GreenText(fmt.Sprint(args...)))
-}
-
-// LogWarnf will output a formatted yellow message to the output log (default stdout)
-func LogWarnf(content string, args ...interface{}) {
-	log.Println(YellowText(fmt.Sprintf(content, args...)))
-}
-
-// LogWarn will output a yellow message to the output log (default stdout)
-func LogWarn(args ...interface{}) {
-	log.Println(YellowText(fmt.Sprint(args...)))
+	fmt.Println(timestamp() + fmt.Sprint(args...))
 }
 
 // LogErrorf will output a formatted red message to the output log (default stdout)
 func LogErrorf(content string, args ...interface{}) {
-	log.Println(fmt.Sprintf(content, args...))
+	log.Println(timestamp() + fmt.Sprintf(content, args...))
 }
 
 // LogError will output a red message to the output log (default stdout)
 func LogError(args ...interface{}) {
-	log.Println(fmt.Sprint(args...))
+	log.Println(timestamp() + fmt.Sprint(args...))
 }
 
 // LogFatalf will output a formatted red message to the output log along with the
 // library information. Then it will quit the application.
 func LogFatalf(content string, args ...interface{}) {
 	log.Println(RedText(LibraryInfo()))
-	log.Fatal(fmt.Sprintf(content, args...))
+	log.Fatal(timestamp() + fmt.Sprintf(content, args...))
 }
 
 // LogFatal will output a red message to the output log along with the
 // library information. Then it will quit the application.
 func LogFatal(args ...interface{}) {
 	log.Println(RedText(LibraryInfo()))
-	log.Fatal(fmt.Sprint(args...))
+	log.Fatal(timestamp() + fmt.Sprint(args...))
 }

--- a/kit/version.go
+++ b/kit/version.go
@@ -28,7 +28,7 @@ func LibraryInfo() string {
 
 // PrintInfo will output the version banner for the themekit library.
 func PrintInfo() {
-	LogNotify(LibraryInfo())
+	Print(GreenText(LibraryInfo()))
 }
 
 // IsNewUpdateAvailable will check if there is an update to the theme kit command
@@ -56,7 +56,7 @@ func InstallThemeKitVersion(ver string) error {
 	} else if ver == "latest" && !requestedRelease.IsApplicable() {
 		return fmt.Errorf("no applicable update available")
 	}
-	LogWarnf("Updating from %s to %s", ThemeKitVersion, requestedRelease.Version)
+	Printf("Updating from %s to %s", YellowText(ThemeKitVersion), YellowText(requestedRelease.Version))
 	err = applyUpdate(requestedRelease.ForCurrentPlatform())
 	if err == nil {
 		Printf(`


### PR DESCRIPTION
fixes #273 

The log now looks like this
![image](https://cloud.githubusercontent.com/assets/463193/20799744/1c1e50ec-b7b1-11e6-9a92-43eb4083df05.png)

I also took out all the extra logging functions so that it is clear where messages are logged, either sdtout or stderr.

@chrisbutcher 