### PR TITLE
Small refactor to dry up filtering code

### DIFF
--- a/kit/event_filter.go
+++ b/kit/event_filter.go
@@ -88,7 +88,7 @@ func (e eventFilter) filterAssets(assets []Asset) []Asset {
 	filteredAssets := []Asset{}
 	sort.Sort(ByAsset(assets))
 	for index, asset := range assets {
-		if !e.matchesFilter(asset.Key) && !assetIsCompiled(asset, assets[index+1:]) {
+		if !assetIsCompiled(asset, assets[index+1:]) && !e.matchesFilter(asset.Key) {
 			filteredAssets = append(filteredAssets, asset)
 		}
 	}

--- a/kit/event_filter.go
+++ b/kit/event_filter.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/ryanuber/go-glob"
@@ -85,8 +86,9 @@ func newEventFilter(rootDir string, patterns []string, files []string) (eventFil
 
 func (e eventFilter) filterAssets(assets []Asset) []Asset {
 	filteredAssets := []Asset{}
-	for _, asset := range assets {
-		if !e.matchesFilter(asset.Key) {
+	sort.Sort(ByAsset(assets))
+	for index, asset := range assets {
+		if !e.matchesFilter(asset.Key) && !assetIsCompiled(asset, assets[index+1:]) {
 			filteredAssets = append(filteredAssets, asset)
 		}
 	}
@@ -135,4 +137,13 @@ func filesToPatterns(files []string) ([]string, error) {
 		patterns = append(patterns, strings.Split(string(data), "\n")...)
 	}
 	return patterns, nil
+}
+
+func assetIsCompiled(a Asset, rest []Asset) bool {
+	for _, other := range rest {
+		if strings.Contains(other.Key, a.Key) {
+			return true
+		}
+	}
+	return false
 }

--- a/kit/event_filter_test.go
+++ b/kit/event_filter_test.go
@@ -39,8 +39,8 @@ func (suite *EventFilterTestSuite) TestNewEventFilter() {
 func (suite *EventFilterTestSuite) TestFilterAssets() {
 	filter, err := newEventFilter(rootDir, []string{".json", "*.txt", "*.gif", "*.ini", "*.bat"}, []string{})
 	if assert.Nil(suite.T(), err) {
-		inputAssets := []Asset{{Key: "test/foo"}, {Key: "foo.txt"}, {Key: "test.bat"}, {Key: "zubat"}}
-		expectedAssets := []Asset{{Key: "test/foo"}, {Key: "zubat"}}
+		inputAssets := []Asset{{Key: "test/foo.json.liquid"}, {Key: "test/foo.json"}, {Key: "foo.txt"}, {Key: "test.bat"}, {Key: "zubat"}}
+		expectedAssets := []Asset{{Key: "test/foo.json.liquid"}, {Key: "zubat"}}
 
 		assert.Equal(suite.T(), expectedAssets, filter.filterAssets(inputAssets))
 	}

--- a/kit/theme_client.go
+++ b/kit/theme_client.go
@@ -3,8 +3,6 @@ package kit
 import (
 	"fmt"
 	"path/filepath"
-	"sort"
-	"strings"
 	"time"
 )
 
@@ -53,8 +51,7 @@ func (t ThemeClient) AssetList() ([]Asset, Error) {
 	if err != nil && err.Fatal() {
 		return []Asset{}, err
 	}
-	sort.Sort(ByAsset(resp.Assets))
-	return t.filter.filterAssets(ignoreCompiledAssets(resp.Assets)), nil
+	return t.filter.filterAssets(resp.Assets), nil
 }
 
 // Asset will load up a single remote asset from the remote shopify servers.
@@ -74,8 +71,7 @@ func (t ThemeClient) LocalAssets() ([]Asset, error) {
 	if err != nil {
 		return []Asset{}, err
 	}
-	sort.Sort(ByAsset(assets))
-	return t.filter.filterAssets(ignoreCompiledAssets(assets)), nil
+	return t.filter.filterAssets(assets), nil
 }
 
 // LocalAsset will load a single local asset on disk. It will return an error if there
@@ -155,24 +151,4 @@ func (t ThemeClient) Perform(asset Asset, event EventType) (*ShopifyResponse, Er
 		return &ShopifyResponse{}, kitError{fmt.Errorf(YellowText(fmt.Sprintf("Asset %s filtered based on ignore patterns", asset.Key)))}
 	}
 	return t.httpClient.AssetAction(event, asset)
-}
-
-func ignoreCompiledAssets(assets []Asset) []Asset {
-	newSize := 0
-	results := make([]Asset, len(assets))
-	isCompiled := func(a Asset, rest []Asset) bool {
-		for _, other := range rest {
-			if strings.Contains(other.Key, a.Key) {
-				return true
-			}
-		}
-		return false
-	}
-	for index, asset := range assets {
-		if !isCompiled(asset, assets[index+1:]) {
-			results[newSize] = asset
-			newSize++
-		}
-	}
-	return results[:newSize]
 }

--- a/kit/theme_client_test.go
+++ b/kit/theme_client_test.go
@@ -216,20 +216,6 @@ func (suite *ThemeClientTestSuite) TestPerform() {
 	assert.NotNil(suite.T(), err)
 }
 
-func (suite *ThemeClientTestSuite) TestIgnoreCompiledAssets() {
-	raw := map[string][]Asset{}
-	bytes := []byte(jsonFixture("responses/assets_raw"))
-	json.Unmarshal(bytes, &raw)
-	sort.Sort(ByAsset(raw["assets"]))
-
-	expected := map[string][]Asset{}
-	bytes = []byte(jsonFixture("responses/assets_filtered"))
-	json.Unmarshal(bytes, &expected)
-	sort.Sort(ByAsset(expected["assets"]))
-
-	assert.Equal(suite.T(), expected["assets"], ignoreCompiledAssets(raw["assets"]))
-}
-
 func (suite *ThemeClientTestSuite) NewTestServer(handler http.HandlerFunc) *httptest.Server {
 	server := httptest.NewServer(handler)
 	suite.client.httpClient.config.Domain = server.URL


### PR DESCRIPTION
We were doing sorting, filtering compiled assets and  filtering ignored files in a couple places so I put all these operation into the filtering code. It has the side effect of doing less looping so slightly more performant, but mostly better code.

@chrisbutcher 