### PR TITLE
Catching less than ideal list errors

### DIFF
--- a/kit/errors.go
+++ b/kit/errors.go
@@ -96,7 +96,7 @@ func newListError(resp ShopifyResponse) listError {
 }
 
 func (err listError) Fatal() bool {
-	return err.resp.Code >= 400
+	return err.resp.Code >= 200 && err.resp.Code < 400
 }
 
 func (err listError) Error() string {


### PR DESCRIPTION
fixes #288 

Connection issues were not being output from the download command because they were not considered fatal. This is because the status code was 0 and so it was not in the fatal range. I have changed the range of fatal code to catch < 200 status codes.

@chrisbutcher 