### PR TITLE
Better file filtering

### DIFF
--- a/kit/file_filter.go
+++ b/kit/file_filter.go
@@ -1,8 +1,6 @@
 package kit
 
 import (
-	"bytes"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"regexp"
@@ -29,16 +27,16 @@ var defaultRegexes = []*regexp.Regexp{
 
 var defaultGlobs = []string{}
 
-type eventFilter struct {
+type fileFilter struct {
 	rootDir string
 	filters []*regexp.Regexp
 	globs   []string
 }
 
-func newEventFilter(rootDir string, patterns []string, files []string) (eventFilter, error) {
+func newFileFilter(rootDir string, patterns []string, files []string) (fileFilter, error) {
 	filePatterns, err := filesToPatterns(files)
 	if err != nil {
-		return eventFilter{}, err
+		return fileFilter{}, err
 	}
 
 	patterns = append(patterns, filePatterns...)
@@ -77,25 +75,25 @@ func newEventFilter(rootDir string, patterns []string, files []string) (eventFil
 		globs = append(globs, rootDir+pattern)
 	}
 
-	return eventFilter{
+	return fileFilter{
 		rootDir: rootDir,
 		filters: filters,
 		globs:   globs,
 	}, nil
 }
 
-func (e eventFilter) filterAssets(assets []Asset) []Asset {
+func (e fileFilter) filterAssets(assets []Asset) []Asset {
 	filteredAssets := []Asset{}
 	sort.Sort(ByAsset(assets))
 	for index, asset := range assets {
-		if !assetIsCompiled(asset, assets[index+1:]) && !e.matchesFilter(asset.Key) {
+		if !e.matchesFilter(asset.Key) && !e.assetIsCompiled(asset, assets[index+1:]) {
 			filteredAssets = append(filteredAssets, asset)
 		}
 	}
 	return filteredAssets
 }
 
-func (e eventFilter) matchesFilter(event string) bool {
+func (e fileFilter) matchesFilter(event string) bool {
 	if len(event) == 0 {
 		return false
 	}
@@ -110,16 +108,6 @@ func (e eventFilter) matchesFilter(event string) bool {
 		}
 	}
 	return false
-}
-
-func (e eventFilter) String() string {
-	buffer := bytes.NewBufferString(strings.Join(e.globs, "\n"))
-	buffer.WriteString("--- endglobs ---\n")
-	for _, rxp := range e.filters {
-		buffer.WriteString(fmt.Sprintf("%s\n", rxp))
-	}
-	buffer.WriteString("-- done --")
-	return buffer.String()
 }
 
 func filesToPatterns(files []string) ([]string, error) {
@@ -139,9 +127,9 @@ func filesToPatterns(files []string) ([]string, error) {
 	return patterns, nil
 }
 
-func assetIsCompiled(a Asset, rest []Asset) bool {
+func (e fileFilter) assetIsCompiled(a Asset, rest []Asset) bool {
 	for _, other := range rest {
-		if strings.Contains(other.Key, a.Key) {
+		if !e.matchesFilter(other.Key) && strings.Contains(other.Key, a.Key) {
 			return true
 		}
 	}

--- a/kit/file_filter_test.go
+++ b/kit/file_filter_test.go
@@ -19,17 +19,17 @@ type EventFilterTestSuite struct {
 
 func (suite *EventFilterTestSuite) TestNewEventFilter() {
 	// loads files
-	filter, err := newEventFilter(rootDir, []string{}, []string{ignoreFixturePath})
+	filter, err := newFileFilter(rootDir, []string{}, []string{ignoreFixturePath})
 	if assert.Nil(suite.T(), err) {
 		assert.Equal(suite.T(), append(defaultRegexes, regexp.MustCompile(`\.(txt|gif|bat)$`)), filter.filters)
 		assert.Equal(suite.T(), []string{"./root/dir/*config/settings.json", "./root/dir/*.png"}, filter.globs)
 	}
 
 	// loads files
-	_, err = newEventFilter(rootDir, []string{}, []string{"bad path"})
+	_, err = newFileFilter(rootDir, []string{}, []string{"bad path"})
 	assert.NotNil(suite.T(), err)
 
-	filter, err = newEventFilter(rootDir, []string{"config/settings.json", "*.png", "/\\.(txt|gif|bat)$/"}, []string{})
+	filter, err = newFileFilter(rootDir, []string{"config/settings.json", "*.png", "/\\.(txt|gif|bat)$/"}, []string{})
 	if assert.Nil(suite.T(), err) {
 		assert.Equal(suite.T(), append(defaultRegexes, regexp.MustCompile(`\.(txt|gif|bat)$`)), filter.filters)
 		assert.Equal(suite.T(), []string{"./root/dir/*config/settings.json", "./root/dir/*.png"}, filter.globs)
@@ -37,7 +37,7 @@ func (suite *EventFilterTestSuite) TestNewEventFilter() {
 }
 
 func (suite *EventFilterTestSuite) TestFilterAssets() {
-	filter, err := newEventFilter(rootDir, []string{".json", "*.txt", "*.gif", "*.ini", "*.bat"}, []string{})
+	filter, err := newFileFilter(rootDir, []string{".json", "*.txt", "*.gif", "*.ini", "*.bat"}, []string{})
 	if assert.Nil(suite.T(), err) {
 		inputAssets := []Asset{{Key: "test/foo.json.liquid"}, {Key: "test/foo.json"}, {Key: "foo.txt"}, {Key: "test.bat"}, {Key: "zubat"}}
 		expectedAssets := []Asset{{Key: "test/foo.json.liquid"}, {Key: "zubat"}}
@@ -47,7 +47,7 @@ func (suite *EventFilterTestSuite) TestFilterAssets() {
 }
 
 func (suite *EventFilterTestSuite) TestMatchesFilter() {
-	check := func(filter eventFilter, input []string, shouldOutput []string) {
+	check := func(filter fileFilter, input []string, shouldOutput []string) {
 		output := []string{}
 		for _, path := range input {
 			if !filter.matchesFilter(path) {
@@ -58,7 +58,7 @@ func (suite *EventFilterTestSuite) TestMatchesFilter() {
 	}
 
 	// it filters plain filenames
-	filter, err := newEventFilter(rootDir, []string{"build/", "test.txt"}, []string{})
+	filter, err := newFileFilter(rootDir, []string{"build/", "test.txt"}, []string{})
 	if assert.Nil(suite.T(), err) {
 		check(
 			filter,
@@ -68,7 +68,7 @@ func (suite *EventFilterTestSuite) TestMatchesFilter() {
 	}
 
 	// it filters globs
-	filter, err = newEventFilter(rootDir, []string{".json", "*.txt", "*.gif", "*.ini", "*.bat"}, []string{})
+	filter, err = newFileFilter(rootDir, []string{".json", "*.txt", "*.gif", "*.ini", "*.bat"}, []string{})
 	if assert.Nil(suite.T(), err) {
 		check(
 			filter,
@@ -78,7 +78,7 @@ func (suite *EventFilterTestSuite) TestMatchesFilter() {
 	}
 
 	// filters proper regex
-	filter, err = newEventFilter(rootDir, []string{`/\.(txt|gif|bat|json|ini)$/`}, []string{})
+	filter, err = newFileFilter(rootDir, []string{`/\.(txt|gif|bat|json|ini)$/`}, []string{})
 	if assert.Nil(suite.T(), err) {
 		check(
 			filter,
@@ -88,7 +88,7 @@ func (suite *EventFilterTestSuite) TestMatchesFilter() {
 	}
 
 	//check default filters
-	filter, err = newEventFilter(rootDir, []string{}, []string{})
+	filter, err = newFileFilter(rootDir, []string{}, []string{})
 	if assert.Nil(suite.T(), err) {
 		check(
 			filter,
@@ -97,7 +97,7 @@ func (suite *EventFilterTestSuite) TestMatchesFilter() {
 		)
 	}
 
-	filter, err = newEventFilter(rootDir, []string{"config/settings_schema.json", "config/settings_data.json", "*.jpg", "*.png"}, []string{})
+	filter, err = newFileFilter(rootDir, []string{"config/settings_schema.json", "config/settings_data.json", "*.jpg", "*.png"}, []string{})
 	if assert.Nil(suite.T(), err) {
 		assert.Equal(suite.T(), false, filter.matchesFilter(""))
 	}

--- a/kit/file_watcher.go
+++ b/kit/file_watcher.go
@@ -38,12 +38,12 @@ type FileWatcher struct {
 	done     chan bool
 	client   ThemeClient
 	watcher  *fsnotify.Watcher
-	filter   eventFilter
+	filter   fileFilter
 	callback FileEventCallback
 	notify   string
 }
 
-func newFileWatcher(client ThemeClient, dir, notifyFile string, recur bool, filter eventFilter, callback FileEventCallback) (*FileWatcher, error) {
+func newFileWatcher(client ThemeClient, dir, notifyFile string, recur bool, filter fileFilter, callback FileEventCallback) (*FileWatcher, error) {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		return nil, err

--- a/kit/file_watcher_test.go
+++ b/kit/file_watcher_test.go
@@ -22,7 +22,7 @@ type FileWatcherTestSuite struct {
 }
 
 func (suite *FileWatcherTestSuite) TestNewFileReader() {
-	watcher, err := newFileWatcher(ThemeClient{}, watchFixturePath, "", true, eventFilter{}, func(ThemeClient, Asset, EventType, error) {})
+	watcher, err := newFileWatcher(ThemeClient{}, watchFixturePath, "", true, fileFilter{}, func(ThemeClient, Asset, EventType, error) {})
 	assert.Nil(suite.T(), err)
 	assert.Equal(suite.T(), true, watcher.IsWatching())
 	watcher.StopWatching()
@@ -67,7 +67,7 @@ func (suite *FileWatcherTestSuite) TestWatchFsEvents() {
 }
 
 func (suite *FileWatcherTestSuite) TestStopWatching() {
-	watcher, err := newFileWatcher(ThemeClient{}, watchFixturePath, "", true, eventFilter{}, func(ThemeClient, Asset, EventType, error) {})
+	watcher, err := newFileWatcher(ThemeClient{}, watchFixturePath, "", true, fileFilter{}, func(ThemeClient, Asset, EventType, error) {})
 	assert.Nil(suite.T(), err)
 	assert.Equal(suite.T(), true, watcher.IsWatching())
 	watcher.StopWatching()

--- a/kit/theme_client.go
+++ b/kit/theme_client.go
@@ -13,7 +13,7 @@ const createThemeMaxRetries int = 3
 type ThemeClient struct {
 	Config     *Configuration
 	httpClient *httpClient
-	filter     eventFilter
+	filter     fileFilter
 }
 
 // NewThemeClient will build a new theme client from a configuration and a theme event
@@ -25,7 +25,7 @@ func NewThemeClient(config *Configuration) (ThemeClient, error) {
 		return ThemeClient{}, err
 	}
 
-	filter, err := newEventFilter(config.Directory, config.IgnoredFiles, config.Ignores)
+	filter, err := newFileFilter(config.Directory, config.IgnoredFiles, config.Ignores)
 	if err != nil {
 		return ThemeClient{}, err
 	}


### PR DESCRIPTION
fixes #287 

First off I renamed `eventFilter` to `fileFilter` since it is used to filter filenames and not just the file watcher events.

Secondly the main problem is that we were filtering out compiled files by filename and not by extension. So it was filtered by thinking that the file path `app.js.liquid` contained the path `app.js` so that means `app.js` is compiled. However this is a problem when one of our users wanted to use source maps so when they had a `theme.css` and a `theme.css.map`, themekit incorrectly assumed that `theme.css` was compiled. So I changed the strategy so the instead themekit checks for the file by checking the list for `app.js`+`.liquid`. This make filtering compiled assets simpler and faster.

@Thibaut @chrisbutcher 