### PR TITLE
Fixing Windows Watch Paths

### DIFF
--- a/kit/asset.go
+++ b/kit/asset.go
@@ -95,7 +95,8 @@ func loadAssetsFromDirectory(dir string, ignore func(path string) bool) ([]Asset
 
 func loadAsset(root, filename string) (asset Asset, err error) {
 	asset = Asset{}
-	path := toSlash(root, filename)
+	path := filepath.ToSlash(filepath.Join(root, filename))
+	path = strings.Replace(path, "\\", "/", -1)
 	file, err := os.Open(path)
 	if err != nil {
 		return asset, fmt.Errorf("loadAsset: %s", err)
@@ -116,21 +117,13 @@ func loadAsset(root, filename string) (asset Asset, err error) {
 		return asset, fmt.Errorf("loadAsset: %s", err)
 	}
 
-	asset = Asset{Key: toSlash(filename)}
+	asset = Asset{Key: filepath.ToSlash(filename)}
 	if contentTypeFor(buffer) == "text" {
 		asset.Value = string(buffer)
 	} else {
 		asset.Attachment = base64.StdEncoding.EncodeToString(buffer)
 	}
 	return asset, nil
-}
-
-func toSlash(path ...string) string {
-	newpath := filepath.ToSlash(filepath.Join(path...))
-	if strings.Index(newpath, "\\") >= 0 {
-		newpath = strings.Replace(newpath, "\\", "/", -1)
-	}
-	return newpath
 }
 
 func contentTypeFor(data []byte) string {

--- a/kit/asset_test.go
+++ b/kit/asset_test.go
@@ -2,7 +2,6 @@ package kit
 
 import (
 	"sort"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -87,7 +86,8 @@ func (s *LoadAssetSuite) TestLoadAssetsFromDirectory() {
 }
 
 func (s *LoadAssetSuite) TestLoadAsset() {
-	windowsRoot := strings.Replace("../fixtures/project", "/", "\\", -1)
+	windowsRoot := "..\\fixtures\\project"
+	println(windowsRoot)
 	asset, err := loadAsset(windowsRoot, "whatever.txt")
 	assert.Equal(s.T(), "whatever.txt", asset.Key)
 	assert.Equal(s.T(), true, asset.IsValid())

--- a/kit/file_watcher.go
+++ b/kit/file_watcher.go
@@ -62,15 +62,16 @@ func newFileWatcher(client ThemeClient, dir, notifyFile string, recur bool, filt
 	return newWatcher, newWatcher.watchDirectory(dir)
 }
 
-func (watcher *FileWatcher) watchDirectory(dir string) error {
-	dir = filepath.Clean(dir)
-	return filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
-		if info.IsDir() && !watcher.filter.matchesFilter(path) && path != dir {
+func (watcher *FileWatcher) watchDirectory(root string) error {
+	root = filepath.Clean(root)
+	return filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if info.IsDir() && !watcher.filter.matchesFilter(path) && path != root {
 			for _, dir := range assetLocations {
-				if strings.HasPrefix(path, dir) {
+				if strings.HasPrefix(path, filepath.Join(root, dir, string(filepath.Separator))) {
 					if err := watcher.watcher.Add(path); err != nil {
 						return fmt.Errorf("Could not watch directory %s: %s", path, err)
 					}
+					break
 				}
 			}
 		}

--- a/kit/file_watcher.go
+++ b/kit/file_watcher.go
@@ -175,14 +175,11 @@ func handleEvent(watcher *FileWatcher, event fsnotify.Event) {
 }
 
 func extractAssetKey(filename string) string {
-	filename = filepath.ToSlash(filename)
-
 	for _, dir := range assetLocations {
 		split := strings.SplitAfterN(filename, dir+string(filepath.Separator), 2)
 		if len(split) > 1 {
-			return filepath.Join(dir, split[len(split)-1])
+			return filepath.ToSlash(filepath.Join(dir, split[len(split)-1]))
 		}
 	}
-
 	return ""
 }

--- a/kit/file_watcher.go
+++ b/kit/file_watcher.go
@@ -17,14 +17,14 @@ const (
 
 var (
 	assetLocations = []string{
-		"templates/customers/",
-		"assets/",
-		"config/",
-		"layout/",
-		"snippets/",
-		"templates/",
-		"locales/",
-		"sections/",
+		filepath.FromSlash("templates/customers"),
+		"assets",
+		"config",
+		"layout",
+		"snippets",
+		"templates",
+		"locales",
+		"sections",
 	}
 )
 
@@ -67,7 +67,7 @@ func (watcher *FileWatcher) watchDirectory(dir string) error {
 	return filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 		if info.IsDir() && !watcher.filter.matchesFilter(path) && path != dir {
 			for _, dir := range assetLocations {
-				if strings.Contains(path+"/", dir) {
+				if strings.HasPrefix(path, dir) {
 					if err := watcher.watcher.Add(path); err != nil {
 						return fmt.Errorf("Could not watch directory %s: %s", path, err)
 					}
@@ -173,9 +173,9 @@ func extractAssetKey(filename string) string {
 	filename = filepath.ToSlash(filename)
 
 	for _, dir := range assetLocations {
-		split := strings.SplitAfterN(filename, dir, 2)
+		split := strings.SplitAfterN(filename, dir+string(filepath.Separator), 2)
 		if len(split) > 1 {
-			return fmt.Sprintf("%s%s", dir, split[len(split)-1])
+			return filepath.Join(dir, split[len(split)-1])
 		}
 	}
 

--- a/kit/file_watcher.go
+++ b/kit/file_watcher.go
@@ -65,6 +65,10 @@ func newFileWatcher(client ThemeClient, dir, notifyFile string, recur bool, filt
 func (watcher *FileWatcher) watchDirectory(root string) error {
 	root = filepath.Clean(root)
 	return filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
 		if info.IsDir() && !watcher.filter.matchesFilter(path) && path != root {
 			for _, dir := range assetLocations {
 				if strings.HasPrefix(path, filepath.Join(root, dir, string(filepath.Separator))) {


### PR DESCRIPTION
fixes #295 
fixes #296 

There is an issue where `templates/customers` is not being watched on windows. This PR will fix this issue and hopefully support paths in a more uniform way.

This is still WIP just because I need to test on a VM still and I don't have the time right now.

@chrisbutcher 