### PR TITLE
Restrict all operations to project files and non filtered files only.

### DIFF
--- a/kit/file_filter.go
+++ b/kit/file_filter.go
@@ -100,20 +100,22 @@ func (e fileFilter) filterAssets(assets []Asset) []Asset {
 	return filteredAssets
 }
 
-func (e fileFilter) matchesFilter(event string) bool {
-	if len(event) == 0 {
-		return false
+func (e fileFilter) matchesFilter(filename string) bool {
+	if len(filename) == 0 || !assetInProject(filename) {
+		return true
 	}
+
 	for _, regexp := range e.filters {
-		if regexp.MatchString(event) {
+		if regexp.MatchString(filename) {
 			return true
 		}
 	}
 	for _, pattern := range e.globs {
-		if glob.Glob(pattern, event) || glob.Glob(pattern, e.rootDir+event) {
+		if glob.Glob(pattern, filename) || glob.Glob(pattern, e.rootDir+filename) {
 			return true
 		}
 	}
+
 	return false
 }
 

--- a/kit/file_filter.go
+++ b/kit/file_filter.go
@@ -101,7 +101,7 @@ func (e fileFilter) filterAssets(assets []Asset) []Asset {
 }
 
 func (e fileFilter) matchesFilter(filename string) bool {
-	if len(filename) == 0 || !assetInProject(filename) {
+	if len(filename) == 0 || !assetInProject(e.rootDir, filename) {
 		return true
 	}
 

--- a/kit/file_filter_test.go
+++ b/kit/file_filter_test.go
@@ -39,8 +39,8 @@ func (suite *EventFilterTestSuite) TestNewEventFilter() {
 func (suite *EventFilterTestSuite) TestFilterAssets() {
 	filter, err := newFileFilter(rootDir, []string{".json", "*.txt", "*.gif", "*.ini", "*.bat"}, []string{})
 	if assert.Nil(suite.T(), err) {
-		inputAssets := []Asset{{Key: "test/foo.json.liquid"}, {Key: "test/foo.json"}, {Key: "foo.txt"}, {Key: "test.bat"}, {Key: "zubat"}}
-		expectedAssets := []Asset{{Key: "test/foo.json.liquid"}, {Key: "zubat"}}
+		inputAssets := []Asset{{Key: "templates/foo.json.liquid"}, {Key: "templates/foo.json"}, {Key: "templates/foo.txt"}, {Key: "test.bat"}, {Key: "templates/zubat"}}
+		expectedAssets := []Asset{{Key: "templates/foo.json.liquid"}, {Key: "templates/zubat"}}
 
 		assert.Equal(suite.T(), expectedAssets, filter.filterAssets(inputAssets))
 	}
@@ -62,8 +62,8 @@ func (suite *EventFilterTestSuite) TestMatchesFilter() {
 	if assert.Nil(suite.T(), err) {
 		check(
 			filter,
-			[]string{rootDir + "/foo/test.txt", "test.txt", "test/test.txt", "build/hello/world", "build/world", "test/build/world", "zubat"},
-			[]string{"zubat"},
+			[]string{rootDir + "/foo/test.txt", "test.txt", "templates/test.txt", "build/hello/world", "build/world", "templates/world", "config/zubat"},
+			[]string{"templates/world", "config/zubat"},
 		)
 	}
 
@@ -72,8 +72,8 @@ func (suite *EventFilterTestSuite) TestMatchesFilter() {
 	if assert.Nil(suite.T(), err) {
 		check(
 			filter,
-			[]string{rootDir + "config/settings.json", "hello.bat", "build/hello/world.gif", "build/world.txt", "whatever", "foo.ini", "zubat"},
-			[]string{"whatever", "zubat"},
+			[]string{rootDir + "config/settings.json", "hello.bat", "build/hello/world.gif", "build/world.txt", "templates/whatever", "foo.ini", "templates/zubat"},
+			[]string{"templates/whatever", "templates/zubat"},
 		)
 	}
 
@@ -82,8 +82,8 @@ func (suite *EventFilterTestSuite) TestMatchesFilter() {
 	if assert.Nil(suite.T(), err) {
 		check(
 			filter,
-			[]string{rootDir + "config/settings.json", "hello.bat", "build/hello/world.gif", "build/world.txt", "whatever", "foo.ini", "zubat"},
-			[]string{"whatever", "zubat"},
+			[]string{rootDir + "config/settings.json", "", "hello.bat", "build/hello/world.gif", "build/world.txt", "templates/whatever", "foo.ini", "templates/zubat"},
+			[]string{"templates/whatever", "templates/zubat"},
 		)
 	}
 
@@ -99,7 +99,7 @@ func (suite *EventFilterTestSuite) TestMatchesFilter() {
 
 	filter, err = newFileFilter(rootDir, []string{"config/settings_schema.json", "config/settings_data.json", "*.jpg", "*.png"}, []string{})
 	if assert.Nil(suite.T(), err) {
-		assert.Equal(suite.T(), false, filter.matchesFilter(""))
+		assert.Equal(suite.T(), true, filter.matchesFilter(""))
 	}
 }
 

--- a/kit/file_watcher.go
+++ b/kit/file_watcher.go
@@ -183,3 +183,13 @@ func extractAssetKey(filename string) string {
 	}
 	return ""
 }
+
+func assetInProject(filename string) bool {
+	for _, dir := range assetLocations {
+		split := strings.SplitAfterN(filename, dir+string(filepath.Separator), 2)
+		if len(split) > 1 {
+			return true
+		}
+	}
+	return false
+}

--- a/kit/file_watcher.go
+++ b/kit/file_watcher.go
@@ -184,10 +184,12 @@ func extractAssetKey(filename string) string {
 	return ""
 }
 
-func assetInProject(filename string) bool {
+func assetInProject(root, filename string) bool {
+	isAbs := strings.Contains(filename, root)
+	filename += string(filepath.Separator)
 	for _, dir := range assetLocations {
-		split := strings.SplitAfterN(filename, dir+string(filepath.Separator), 2)
-		if len(split) > 1 {
+		path := filepath.Join(root, dir) + string(filepath.Separator)
+		if (isAbs && strings.HasPrefix(filename, path)) || strings.HasPrefix(filename, dir+string(filepath.Separator)) {
 			return true
 		}
 	}

--- a/kit/file_watcher_test.go
+++ b/kit/file_watcher_test.go
@@ -123,6 +123,25 @@ func (suite *FileWatcherTestSuite) TestExtractAssetKey() {
 	}
 }
 
+func (suite *FileWatcherTestSuite) TestAssetInProject() {
+	tests := map[string]bool{
+		"": false,
+		"/long/path/to/config.yml":                      false,
+		"/long/path/to/misc/other.html":                 false,
+		"/long/path/to/assets/logo.png":                 true,
+		"/long/path/to/templates/customers/test.liquid": true,
+		"/long/path/to/config/test.liquid":              true,
+		"/long/path/to/layout/test.liquid":              true,
+		"/long/path/to/snippets/test.liquid":            true,
+		"/long/path/to/templates/test.liquid":           true,
+		"/long/path/to/locales/test.liquid":             true,
+		"/long/path/to/sections/test.liquid":            true,
+	}
+	for input, expected := range tests {
+		assert.Equal(suite.T(), expected, assetInProject(input))
+	}
+}
+
 func TestFileWatcherTestSuite(t *testing.T) {
 	suite.Run(t, new(FileWatcherTestSuite))
 }

--- a/kit/file_watcher_test.go
+++ b/kit/file_watcher_test.go
@@ -34,8 +34,11 @@ func (suite *FileWatcherTestSuite) TestWatchFsEvents() {
 	var wg sync.WaitGroup
 	wg.Add(2)
 
+	filter, _ := newFileFilter(watchFixturePath, []string{}, []string{})
+
 	newWatcher := &FileWatcher{
 		done:    make(chan bool),
+		filter:  filter,
 		watcher: &fsnotify.Watcher{Events: eventChan},
 	}
 
@@ -127,18 +130,27 @@ func (suite *FileWatcherTestSuite) TestAssetInProject() {
 	tests := map[string]bool{
 		"": false,
 		"/long/path/to/config.yml":                      false,
+		"/long/path/to/misc":                            false,
 		"/long/path/to/misc/other.html":                 false,
+		"/long/path/to/assets":                          true,
 		"/long/path/to/assets/logo.png":                 true,
+		"/long/path/to/templates/customers":             true,
 		"/long/path/to/templates/customers/test.liquid": true,
+		"/long/path/to/config":                          true,
 		"/long/path/to/config/test.liquid":              true,
 		"/long/path/to/layout/test.liquid":              true,
+		"/long/path/to/layout":                          true,
 		"/long/path/to/snippets/test.liquid":            true,
+		"/long/path/to/snippets":                        true,
 		"/long/path/to/templates/test.liquid":           true,
+		"/long/path/to/templates":                       true,
 		"/long/path/to/locales/test.liquid":             true,
+		"/long/path/to/locales":                         true,
 		"/long/path/to/sections/test.liquid":            true,
+		"/long/path/to/sections":                        true,
 	}
 	for input, expected := range tests {
-		assert.Equal(suite.T(), expected, assetInProject(input))
+		assert.Equal(suite.T(), expected, assetInProject("/long/path/to", input), input)
 	}
 }
 

--- a/kit/theme_client_test.go
+++ b/kit/theme_client_test.go
@@ -88,7 +88,7 @@ func (suite *ThemeClientTestSuite) TestAsset() {
 func (suite *ThemeClientTestSuite) TestLocalAssets() {
 	assets, err := suite.client.LocalAssets()
 	assert.Nil(suite.T(), err)
-	assert.Equal(suite.T(), 10, len(assets))
+	assert.Equal(suite.T(), 7, len(assets))
 
 	suite.client.Config.Directory = "./nope"
 	_, err = suite.client.LocalAssets()


### PR DESCRIPTION
fixes #300 

Filtering out files that are not in the project workspace for all actions. This will minimize all the 404 responses from file not being in the project workspace. It will also minimize requests to Shopify which will make upload and replace faster since there are no wasted connections.

@chrisbutcher @stevebosworth 