### PR TITLE
Fixing windows path handling in 0.6.2

### DIFF
--- a/fixtures/project/assets/application.js
+++ b/fixtures/project/assets/application.js
@@ -1,0 +1,1 @@
+//this is js

--- a/kit/asset.go
+++ b/kit/asset.go
@@ -117,7 +117,7 @@ func loadAsset(root, filename string) (asset Asset, err error) {
 		return asset, fmt.Errorf("loadAsset: %s", err)
 	}
 
-	asset = Asset{Key: filepath.ToSlash(filename)}
+	asset = Asset{Key: pathToProject(path)}
 	if contentTypeFor(buffer) == "text" {
 		asset.Value = string(buffer)
 	} else {

--- a/kit/asset_test.go
+++ b/kit/asset_test.go
@@ -73,35 +73,33 @@ func (s *LoadAssetSuite) TestFindAllFiles() {
 }
 
 func (s *LoadAssetSuite) TestLoadAssetsFromDirectory() {
-	assets, err := loadAssetsFromDirectory("../fixtures/project/valid_patterns", func(path string) bool { return false })
+	assets, err := loadAssetsFromDirectory(clean("../fixtures/project/valid_patterns"), func(path string) bool { return false })
 	assert.Equal(s.T(), "Path is not a directory", err.Error())
-	assets, err = loadAssetsFromDirectory("../fixtures/project", func(path string) bool {
-		return path != "whatever.txt"
+	assets, err = loadAssetsFromDirectory(clean("../fixtures/project"), func(path string) bool {
+		return path != "assets/application.js"
 	})
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), []Asset{{
-		Key:   "whatever.txt",
-		Value: "whatever\n",
+		Key:   "assets/application.js",
+		Value: "//this is js\n",
 	}}, assets)
 }
 
 func (s *LoadAssetSuite) TestLoadAsset() {
-	windowsRoot := "..\\fixtures\\project"
-	println(windowsRoot)
-	asset, err := loadAsset(windowsRoot, "whatever.txt")
-	assert.Equal(s.T(), "whatever.txt", asset.Key)
+	asset, err := loadAsset(clean("../fixtures/project"), clean("assets/application.js"))
+	assert.Equal(s.T(), "assets/application.js", asset.Key)
 	assert.Equal(s.T(), true, asset.IsValid())
-	assert.Equal(s.T(), "whatever\n", asset.Value)
+	assert.Equal(s.T(), "//this is js\n", asset.Value)
 	assert.Nil(s.T(), err)
 
-	asset, err = loadAsset("../fixtures/project", "nope.txt")
+	asset, err = loadAsset(clean("../fixtures/project"), "nope.txt")
 	assert.NotNil(s.T(), err)
 
-	asset, err = loadAsset("../fixtures/project", "templates")
+	asset, err = loadAsset(clean("../fixtures/project"), "templates")
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), "loadAsset: File is a directory", err.Error())
 
-	asset, err = loadAsset("../fixtures/project", "assets/pixel.png")
+	asset, err = loadAsset(clean("../fixtures/project"), "assets/pixel.png")
 	assert.Nil(s.T(), err)
 	assert.True(s.T(), len(asset.Attachment) > 0)
 	assert.True(s.T(), asset.IsValid())

--- a/kit/environments_test.go
+++ b/kit/environments_test.go
@@ -35,7 +35,7 @@ func (suite *EnvironmentsTestSuite) TestLoadEnvironments() {
 	_, err := LoadEnvironments(badEnvirontmentPath)
 	assert.NotNil(suite.T(), err)
 
-	_, err = LoadEnvironments("./not/there.yml")
+	_, err = LoadEnvironments(clean("./not/there.yml"))
 	assert.NotNil(suite.T(), err)
 }
 
@@ -44,11 +44,11 @@ func (suite *EnvironmentsTestSuite) TestSearchConfigPath() {
 	assert.Nil(suite.T(), err)
 	assert.Equal(suite.T(), "yml", ext)
 
-	_, ext, err = searchConfigPath("../fixtures/project/config.json")
+	_, ext, err = searchConfigPath(clean("../fixtures/project/config.json"))
 	assert.Nil(suite.T(), err)
 	assert.Equal(suite.T(), "json", ext)
 
-	_, ext, err = searchConfigPath("./not/there.yml")
+	_, ext, err = searchConfigPath(clean("./not/there.yml"))
 	assert.NotNil(suite.T(), err)
 	assert.Equal(suite.T(), os.ErrNotExist, err)
 }
@@ -71,7 +71,7 @@ func (suite *EnvironmentsTestSuite) TestSave() {
 	assert.Nil(suite.T(), err)
 	_, err = os.Stat(outputEnvirontmentPath)
 	assert.Nil(suite.T(), err)
-	err = suite.environments.Save("./no/where/path")
+	err = suite.environments.Save(clean("./no/where/path"))
 	assert.NotNil(suite.T(), err)
 }
 

--- a/kit/file_filter.go
+++ b/kit/file_filter.go
@@ -101,7 +101,7 @@ func (e fileFilter) filterAssets(assets []Asset) []Asset {
 }
 
 func (e fileFilter) matchesFilter(filename string) bool {
-	if len(filename) == 0 || !assetInProject(e.rootDir, filename) {
+	if len(filename) == 0 || !pathInProject(filename) {
 		return true
 	}
 

--- a/kit/file_filter_test.go
+++ b/kit/file_filter_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-const (
+var (
 	rootDir           = "./root/dir/"
 	ignoreFixturePath = "../fixtures/project/valid_patterns"
 )

--- a/kit/path.go
+++ b/kit/path.go
@@ -1,0 +1,50 @@
+package kit
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+var (
+	assetLocations = []string{
+		"templates/customers",
+		"assets",
+		"config",
+		"layout",
+		"snippets",
+		"templates",
+		"locales",
+		"sections",
+	}
+)
+
+func pathInProject(filename string) bool {
+	return pathToProject(filename) != "" || isProjectDirectory(filename)
+}
+
+func isProjectDirectory(filename string) bool {
+	for _, dir := range assetLocations {
+		if directoriesEqual(filename, dir) {
+			return true
+		}
+	}
+	return false
+}
+
+func directoriesEqual(dir, other string) bool {
+	return strings.HasSuffix(
+		filepath.Clean(filepath.ToSlash(dir)+"/"),
+		filepath.Clean(filepath.ToSlash(other)+"/"),
+	)
+}
+
+func pathToProject(filename string) string {
+	filename = filepath.ToSlash(filepath.Clean(filename))
+	for _, dir := range assetLocations {
+		split := strings.SplitAfterN(filename, dir+"/", 2)
+		if len(split) > 1 {
+			return filepath.ToSlash(filepath.Join(dir, split[len(split)-1]))
+		}
+	}
+	return ""
+}

--- a/kit/path_test.go
+++ b/kit/path_test.go
@@ -1,0 +1,71 @@
+package kit
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type PathTestSuite struct {
+	suite.Suite
+}
+
+func (suite *PathTestSuite) TestPathToProject() {
+	tests := map[string]string{
+		filepath.Join("long", "path", "to", "config.yml"):                            "",
+		filepath.Join("long", "path", "to", "assets", "logo.png"):                    "assets/logo.png",
+		filepath.Join("long", "path", "to", "templates", "customers", "test.liquid"): "templates/customers/test.liquid",
+		filepath.Join("long", "path", "to", "config", "test.liquid"):                 "config/test.liquid",
+		filepath.Join("long", "path", "to", "layout", "test.liquid"):                 "layout/test.liquid",
+		filepath.Join("long", "path", "to", "snippets", "test.liquid"):               "snippets/test.liquid",
+		filepath.Join("long", "path", "to", "templates", "test.liquid"):              "templates/test.liquid",
+		filepath.Join("long", "path", "to", "locales", "test.liquid"):                "locales/test.liquid",
+		filepath.Join("long", "path", "to", "sections", "test.liquid"):               "sections/test.liquid",
+	}
+	for input, expected := range tests {
+		assert.Equal(suite.T(), expected, pathToProject(input))
+	}
+}
+
+func (suite *PathTestSuite) TestDirInProject() {
+	tests := map[string]bool{
+		"": false,
+		filepath.Join("long", "path", "to", "misc"):                false,
+		filepath.Join("long", "path", "to", "assets"):              true,
+		filepath.Join("long", "path", "to", "templates/customers"): true,
+		filepath.Join("long", "path", "to", "config"):              true,
+		filepath.Join("long", "path", "to", "layout"):              true,
+		filepath.Join("long", "path", "to", "snippets"):            true,
+		filepath.Join("long", "path", "to", "templates"):           true,
+		filepath.Join("long", "path", "to", "locales"):             true,
+		filepath.Join("long", "path", "to", "sections"):            true,
+	}
+	for input, expected := range tests {
+		assert.Equal(suite.T(), expected, isProjectDirectory(input), input)
+	}
+}
+
+func (suite *PathTestSuite) TestPathInProject() {
+	tests := map[string]bool{
+		"": false,
+		filepath.Join("long", "path", "to", "config.yml"):                            false,
+		filepath.Join("long", "path", "to", "misc", "other.html"):                    false,
+		filepath.Join("long", "path", "to", "assets", "logo.png"):                    true,
+		filepath.Join("long", "path", "to", "templates", "customers", "test.liquid"): true,
+		filepath.Join("long", "path", "to", "config", "test.liquid"):                 true,
+		filepath.Join("long", "path", "to", "layout", "test.liquid"):                 true,
+		filepath.Join("long", "path", "to", "snippets", "test.liquid"):               true,
+		filepath.Join("long", "path", "to", "templates", "test.liquid"):              true,
+		filepath.Join("long", "path", "to", "locales", "test.liquid"):                true,
+		filepath.Join("long", "path", "to", "sections", "test.liquid"):               true,
+	}
+	for input, expected := range tests {
+		assert.Equal(suite.T(), expected, pathInProject(input), input)
+	}
+}
+
+func TestPathTestSuite(t *testing.T) {
+	suite.Run(t, new(PathTestSuite))
+}

--- a/kit/theme_client.go
+++ b/kit/theme_client.go
@@ -2,7 +2,6 @@ package kit
 
 import (
 	"fmt"
-	"path/filepath"
 	"time"
 )
 
@@ -66,8 +65,7 @@ func (t ThemeClient) Asset(filename string) (Asset, Error) {
 // LocalAssets will return a slice of assets from the local disk. The
 // assets are filtered based on your config.
 func (t ThemeClient) LocalAssets() ([]Asset, error) {
-	dir := fmt.Sprintf("%s%s", t.Config.Directory, string(filepath.Separator))
-	assets, err := loadAssetsFromDirectory(dir, t.filter.matchesFilter)
+	assets, err := loadAssetsFromDirectory(t.Config.Directory, t.filter.matchesFilter)
 	if err != nil {
 		return []Asset{}, err
 	}


### PR DESCRIPTION
fixes #308
fixes #307 
fixes #305 

I finally bit the bullet and just isolated path functions so that they can be maintained in a separate environment and not be effected by other changes. All the path handling is in one spot within helpers that can be used outside of there so that the path manipulation doesn't change. Also since the file filtering now filters files to be strictly inside the project, this cleared up the amount of spots that paths are checked

@chrisbutcher 
