### PR TITLE
Fixing remove event in file watcher

### DIFF
--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -24,7 +24,6 @@ For more documentation please see http://shopify.github.io/themekit/commands/#up
 }
 
 func upload(client kit.ThemeClient, filenames []string, wg *sync.WaitGroup) {
-	fmt.Println(filenames)
 	defer wg.Done()
 
 	if client.Config.ReadOnly {

--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/spf13/cobra"
@@ -23,6 +24,7 @@ For more documentation please see http://shopify.github.io/themekit/commands/#up
 }
 
 func upload(client kit.ThemeClient, filenames []string, wg *sync.WaitGroup) {
+	fmt.Println(filenames)
 	defer wg.Done()
 
 	if client.Config.ReadOnly {

--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"sync"
 
 	"github.com/spf13/cobra"

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -62,12 +62,7 @@ func watch(themeClients []kit.ThemeClient) error {
 	return nil
 }
 
-func handleWatchEvent(client kit.ThemeClient, asset kit.Asset, event kit.EventType, err error) {
-	if err != nil {
-		kit.LogErrorf("[%s]%s", kit.GreenText(client.Config.Environment), err)
-		return
-	}
-
+func handleWatchEvent(client kit.ThemeClient, asset kit.Asset, event kit.EventType) {
 	kit.Printf(
 		"[%s] Received %s event on %s",
 		kit.GreenText(client.Config.Environment),

--- a/cmd/watch_test.go
+++ b/cmd/watch_test.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"os"
 	"testing"
@@ -52,9 +51,7 @@ func (suite *WatchTestSuite) TestHandleWatchEvent() {
 	})
 	defer server.Close()
 
-	handleWatchEvent(client, kit.Asset{Key: "templates/layout.liquid"}, kit.Remove, fmt.Errorf("bad watch event"))
-
-	handleWatchEvent(client, kit.Asset{Key: "templates/layout.liquid"}, kit.Remove, nil)
+	handleWatchEvent(client, kit.Asset{Key: "templates/layout.liquid"}, kit.Remove)
 
 	assert.Equal(suite.T(), 1, len(requests))
 }

--- a/kit/asset.go
+++ b/kit/asset.go
@@ -94,9 +94,9 @@ func loadAssetsFromDirectory(dir string, ignore func(path string) bool) ([]Asset
 }
 
 func loadAsset(root, filename string) (asset Asset, err error) {
-	asset = Asset{}
 	path := filepath.ToSlash(filepath.Join(root, filename))
 	path = strings.Replace(path, "\\", "/", -1)
+	asset = Asset{Key: pathToProject(path)}
 	file, err := os.Open(path)
 	if err != nil {
 		return asset, fmt.Errorf("loadAsset: %s", err)
@@ -117,7 +117,6 @@ func loadAsset(root, filename string) (asset Asset, err error) {
 		return asset, fmt.Errorf("loadAsset: %s", err)
 	}
 
-	asset = Asset{Key: pathToProject(path)}
 	if contentTypeFor(buffer) == "text" {
 		asset.Value = string(buffer)
 	} else {

--- a/kit/file_watcher.go
+++ b/kit/file_watcher.go
@@ -16,7 +16,7 @@ const (
 
 // FileEventCallback is the callback that is called when there is an event from
 // a file watcher.
-type FileEventCallback func(ThemeClient, Asset, EventType, error)
+type FileEventCallback func(ThemeClient, Asset, EventType)
 
 // FileWatcher is the object used to watch files for change and notify on any events,
 // these events can then be passed along to kit to be sent to shopify.
@@ -137,6 +137,6 @@ func handleEvent(watcher *FileWatcher, event fsnotify.Event) {
 	if event.Op&fsnotify.Remove == fsnotify.Remove {
 		eventType = Remove
 	}
-	asset, err := loadAsset(filepath.Dir(event.Name), filepath.Base(event.Name))
-	watcher.callback(watcher.client, asset, eventType, err)
+	asset, _ := loadAsset(filepath.Dir(event.Name), filepath.Base(event.Name))
+	watcher.callback(watcher.client, asset, eventType)
 }

--- a/kit/file_watcher_test.go
+++ b/kit/file_watcher_test.go
@@ -23,7 +23,7 @@ type FileWatcherTestSuite struct {
 }
 
 func (suite *FileWatcherTestSuite) TestNewFileReader() {
-	watcher, err := newFileWatcher(ThemeClient{}, watchFixturePath, "", true, fileFilter{}, func(ThemeClient, Asset, EventType, error) {})
+	watcher, err := newFileWatcher(ThemeClient{}, watchFixturePath, "", true, fileFilter{}, func(ThemeClient, Asset, EventType) {})
 	assert.Nil(suite.T(), err)
 	assert.Equal(suite.T(), true, watcher.IsWatching())
 	watcher.StopWatching()
@@ -43,8 +43,7 @@ func (suite *FileWatcherTestSuite) TestWatchFsEvents() {
 		watcher: &fsnotify.Watcher{Events: eventChan},
 	}
 
-	newWatcher.callback = func(client ThemeClient, asset Asset, event EventType, err error) {
-		assert.Nil(suite.T(), err)
+	newWatcher.callback = func(client ThemeClient, asset Asset, event EventType) {
 		assert.Equal(suite.T(), Update, event)
 		assetChan <- asset
 		wg.Done()
@@ -71,7 +70,7 @@ func (suite *FileWatcherTestSuite) TestWatchFsEvents() {
 }
 
 func (suite *FileWatcherTestSuite) TestStopWatching() {
-	watcher, err := newFileWatcher(ThemeClient{}, watchFixturePath, "", true, fileFilter{}, func(ThemeClient, Asset, EventType, error) {})
+	watcher, err := newFileWatcher(ThemeClient{}, watchFixturePath, "", true, fileFilter{}, func(ThemeClient, Asset, EventType) {})
 	assert.Nil(suite.T(), err)
 	assert.Equal(suite.T(), true, watcher.IsWatching())
 	watcher.StopWatching()
@@ -92,13 +91,12 @@ func (suite *FileWatcherTestSuite) TestHandleEvent() {
 	var wg sync.WaitGroup
 	wg.Add(len(writes))
 
-	watcher := &FileWatcher{callback: func(client ThemeClient, asset Asset, event EventType, err error) {
+	watcher := &FileWatcher{callback: func(client ThemeClient, asset Asset, event EventType) {
 		assert.Equal(suite.T(), pathToProject(textFixturePath), asset.Key)
 		wg.Done()
 	}}
 
 	for _, write := range writes {
-		println(write.Name)
 		handleEvent(watcher, fsnotify.Event{Name: write.Name, Op: write.Event})
 	}
 

--- a/kit/theme_client_test.go
+++ b/kit/theme_client_test.go
@@ -50,7 +50,7 @@ func (suite *ThemeClientTestSuite) TestNewThemeClientError() {
 }
 
 func (suite *ThemeClientTestSuite) TestNewFileWatcher() {
-	watcher, err := suite.client.NewFileWatcher("", func(ThemeClient, Asset, EventType, error) {})
+	watcher, err := suite.client.NewFileWatcher("", func(ThemeClient, Asset, EventType) {})
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), watcher)
 }


### PR DESCRIPTION
fixes #312 

The asset loading became more strict in the last version but did not account for file removal in watching. This PR fixes that. Also since the watcher no longer returns any errors the callback interface was simplified.

@chrisbutcher @ilikeorangutans 