### PR TITLE
Update docs to correct directory flag

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -81,7 +81,7 @@ debugging settings or scripting calls to Theme Kit from something like `cron`.
 | password     | `--password`    |         |
 | theme_id     | `--themeid`     |         |
 | store        | `--store`       | -s      |
-| directory    | `--directory`   | -d      |
+| directory    | `--dir`         | -d      |
 | ignore_files | `--ignored-file`|         |
 | ignores      | `--ignores`     |         |
 | proxy        | `--proxy`       |         |


### PR DESCRIPTION
`--directory` is not a valid flag, however `--dir` is. Updated docs to match.