### PR TITLE
Took out values and attachments from asset list queries

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -45,9 +45,7 @@ func download(client kit.ThemeClient, filenames []string) error {
 
 	for _, filename := range filenames {
 		wg.Add(1)
-		if err := downloadFile(client, filename, &wg); err != nil {
-			return err
-		}
+		go downloadFile(client, filename, &wg)
 	}
 
 	wg.Wait()
@@ -55,24 +53,19 @@ func download(client kit.ThemeClient, filenames []string) error {
 	return nil
 }
 
-func downloadFile(client kit.ThemeClient, filename string, wg *sync.WaitGroup) error {
+func downloadFile(client kit.ThemeClient, filename string, wg *sync.WaitGroup) {
 	defer wg.Done()
-
-	kit.Printf("[%s] Downloading %s from %s",
-		kit.GreenText(client.Config.Environment),
-		filename,
-		kit.YellowText(client.Config.Domain))
 
 	asset, err := client.Asset(filename)
 	if err != nil {
-		return err
+		kit.LogErrorf("[%s]%s", kit.GreenText(client.Config.Environment), err)
+		return
 	}
 
 	if err := asset.Write(client.Config.Directory); err != nil {
-		return err
+		kit.LogErrorf("[%s]%s", kit.GreenText(client.Config.Environment), err)
+		return
 	}
 
 	kit.Print(kit.GreenText(fmt.Sprintf("[%s] Successfully wrote %s to disk", client.Config.Environment, filename)))
-
-	return nil
 }

--- a/cmd/download_test.go
+++ b/cmd/download_test.go
@@ -41,7 +41,7 @@ func (suite *DownloadTestSuite) TestDownloadWithFileNames() {
 
 	client.Config.ReadOnly = true
 	err = download(client, []string{"output/nope.txt"})
-	assert.NotNil(suite.T(), err)
+	assert.Nil(suite.T(), err)
 }
 
 func (suite *DownloadTestSuite) TestDownloadAll() {

--- a/cmd/download_test.go
+++ b/cmd/download_test.go
@@ -27,7 +27,6 @@ func (suite *DownloadTestSuite) TestDownloadWithFileNames() {
 	defer os.Remove("../fixtures/project/assets/hello.txt")
 	defer os.Remove("../fixtures/project/assets/hello.txt")
 	client, server := newClientAndTestServer(func(w http.ResponseWriter, r *http.Request) {
-		println(r.URL.RawQuery)
 		if "asset[key]=assets/hello.txt" == r.URL.RawQuery {
 			fmt.Fprintf(w, jsonFixture("responses/asset"))
 		} else {

--- a/cmd/download_test.go
+++ b/cmd/download_test.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"encoding/base64"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -11,8 +10,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-
-	"github.com/Shopify/themekit/kit"
 )
 
 const outputPath = "../fixtures/fomatted_output.json"
@@ -30,7 +27,8 @@ func (suite *DownloadTestSuite) TestDownloadWithFileNames() {
 	defer os.Remove("../fixtures/project/assets/hello.txt")
 	defer os.Remove("../fixtures/project/assets/hello.txt")
 	client, server := newClientAndTestServer(func(w http.ResponseWriter, r *http.Request) {
-		if "fields=key,attachment,value&asset[key]=assets/hello.txt" == r.URL.RawQuery {
+		println(r.URL.RawQuery)
+		if "asset[key]=assets/hello.txt" == r.URL.RawQuery {
 			fmt.Fprintf(w, jsonFixture("responses/asset"))
 		} else {
 			w.WriteHeader(404)
@@ -57,54 +55,7 @@ func (suite *DownloadTestSuite) TestDownloadAll() {
 	os.MkdirAll(client.Config.Directory, 7777)
 	defer os.Remove(client.Config.Directory)
 
-	err := download(client, []string{})
-	assert.Nil(suite.T(), err)
-}
-
-func (suite *DownloadTestSuite) TestWriteToDisk() {
-	asset := kit.Asset{Key: "output/blah.txt", Value: "this is content"}
-
-	err := writeToDisk("../nope", asset)
-	assert.NotNil(suite.T(), err)
-
-	err = writeToDisk("../fixtures", asset)
-	assert.Nil(suite.T(), err)
-}
-
-func (suite *DownloadTestSuite) TestGetAssetContents() {
-	data, err := getAssetContents(kit.Asset{Value: "this is content"})
-	assert.Nil(suite.T(), err)
-	assert.Equal(suite.T(), 15, len(data))
-
-	data, err = getAssetContents(kit.Asset{Attachment: "this is bad content"})
-	assert.NotNil(suite.T(), err)
-
-	data, err = getAssetContents(kit.Asset{Attachment: base64.StdEncoding.EncodeToString([]byte("this is bad content"))})
-	assert.Nil(suite.T(), err)
-	assert.Equal(suite.T(), 19, len(data))
-	assert.Equal(suite.T(), []byte("this is bad content"), data)
-}
-
-func (suite *DownloadTestSuite) TestFormatWrite() {
-	file, _ := os.Create(outputPath)
-
-	n, err := formatWrite(file, []byte{})
-	assert.Nil(suite.T(), err)
-	assert.Equal(suite.T(), 0, n)
-
-	n, err = formatWrite(file, []byte("{\"test\":\"one\"}"))
-	assert.Nil(suite.T(), err)
-	assert.Equal(suite.T(), 19, n)
-	file.Close()
-
-	file, _ = os.Open(outputPath)
-	buffer, err := ioutil.ReadAll(file)
-	assert.Equal(suite.T(), `{
-  "test": "one"
-}`, string(buffer))
-	assert.Nil(suite.T(), err)
-
-	os.Remove(outputPath)
+	assert.Nil(suite.T(), download(client, []string{}))
 }
 
 func TestDownloadTestSuite(t *testing.T) {

--- a/kit/http_client.go
+++ b/kit/http_client.go
@@ -84,12 +84,14 @@ func (client *httpClient) ThemePath(themeID int64) string {
 }
 
 func (client *httpClient) AssetQuery(event EventType, query map[string]string) (*ShopifyResponse, Error) {
-	path := fmt.Sprintf("%s?fields=key,attachment,value", client.AssetPath())
+	querystr := []string{}
 	for key, value := range query {
-		path += "&" + key + "=" + value
+		querystr = append(querystr, key+"="+value)
 	}
+	path := client.AssetPath()
 	rtype := listRequest
-	if len(query) > 0 {
+	if len(querystr) > 0 {
+		path += "?" + strings.Join(querystr, "&")
 		rtype = assetRequest
 	}
 	return client.sendRequest(rtype, event, path, nil)

--- a/kit/http_client_test.go
+++ b/kit/http_client_test.go
@@ -79,7 +79,7 @@ func (suite *HTTPClientTestSuite) TestThemePath() {
 func (suite *HTTPClientTestSuite) TestAssetQuery() {
 	server := suite.NewTestServer(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(suite.T(), "GET", r.Method)
-		assert.Equal(suite.T(), "fields=key,attachment,value", r.URL.RawQuery)
+		assert.Equal(suite.T(), "", r.URL.RawQuery)
 		fmt.Fprintf(w, jsonFixture("responses/assets"))
 	})
 	resp, err := suite.client.AssetQuery(Retrieve, map[string]string{})
@@ -90,7 +90,7 @@ func (suite *HTTPClientTestSuite) TestAssetQuery() {
 
 	server = suite.NewTestServer(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(suite.T(), "GET", r.Method)
-		assert.Equal(suite.T(), "fields=key,attachment,value&asset[key]=file.txt", r.URL.RawQuery)
+		assert.Equal(suite.T(), "asset[key]=file.txt", r.URL.RawQuery)
 		fmt.Fprintf(w, jsonFixture("responses/asset"))
 	})
 	resp, err = suite.client.AssetQuery(Retrieve, map[string]string{"asset[key]": "file.txt"})

--- a/kit/theme_client.go
+++ b/kit/theme_client.go
@@ -45,6 +45,8 @@ func (t ThemeClient) NewFileWatcher(notifyFile string, callback FileEventCallbac
 
 // AssetList will return a slice of remote assets from the shopify servers. The
 // assets are sorted and any ignored files based on your config are filtered out.
+// The assets returned will not have any data, only ID and filenames. This is because
+// fetching all the assets at one time is not a good idea.
 func (t ThemeClient) AssetList() ([]Asset, Error) {
 	resp, err := t.httpClient.AssetQuery(Retrieve, map[string]string{})
 	if err != nil && err.Fatal() {

--- a/kit/theme_client_test.go
+++ b/kit/theme_client_test.go
@@ -58,7 +58,7 @@ func (suite *ThemeClientTestSuite) TestNewFileWatcher() {
 func (suite *ThemeClientTestSuite) TestAssetList() {
 	server := suite.NewTestServer(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(suite.T(), "GET", r.Method)
-		assert.Equal(suite.T(), "fields=key,attachment,value", r.URL.RawQuery)
+		assert.Equal(suite.T(), "", r.URL.RawQuery)
 		fmt.Fprintf(w, jsonFixture("responses/assets_raw"))
 	})
 	defer server.Close()
@@ -76,7 +76,7 @@ func (suite *ThemeClientTestSuite) TestAssetList() {
 func (suite *ThemeClientTestSuite) TestAsset() {
 	server := suite.NewTestServer(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(suite.T(), "GET", r.Method)
-		assert.Equal(suite.T(), "fields=key,attachment,value&asset[key]=file.txt", r.URL.RawQuery)
+		assert.Equal(suite.T(), "asset[key]=file.txt", r.URL.RawQuery)
 		fmt.Fprintf(w, jsonFixture("responses/asset"))
 	})
 	defer server.Close()


### PR DESCRIPTION
fixes #318 

ThemeKit was using an API endpoint incorrectly so asset listing had to be changed to take out the attachment and value data from the list queries. (https://github.com/Shopify/shopify/issues/98379)

This will make download and replace a lot more dependable for larger themes however it does *feel* slower to download. It will however make replace much faster.

@chrisbutcher 

cc @NathanPJF @DrewMartin @nicday @Thibaut Just to let you know that I have managed a fix for this issue.