### PR TITLE
Upload directories and download wildcards

### DIFF
--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -30,24 +30,10 @@ func upload(client kit.ThemeClient, filenames []string, wg *sync.WaitGroup) {
 		return
 	}
 
-	var err error
-	localAssets := []kit.Asset{}
-
-	if len(filenames) == 0 {
-		localAssets, err = client.LocalAssets()
-		if err != nil {
-			kit.LogError(err)
-			return
-		}
-	} else {
-		for _, filename := range filenames {
-			asset, err := client.LocalAsset(filename)
-			if err != nil {
-				kit.LogError(err)
-				return
-			}
-			localAssets = append(localAssets, asset)
-		}
+	localAssets, err := client.LocalAssets(filenames...)
+	if err != nil {
+		kit.LogError(err)
+		return
 	}
 
 	for _, asset := range localAssets {

--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -32,7 +32,7 @@ func upload(client kit.ThemeClient, filenames []string, wg *sync.WaitGroup) {
 
 	localAssets, err := client.LocalAssets(filenames...)
 	if err != nil {
-		kit.LogError(err)
+		kit.LogErrorf("[%s] %v", kit.GreenText(client.Config.Environment), err)
 		return
 	}
 

--- a/cmd/upload_test.go
+++ b/cmd/upload_test.go
@@ -38,6 +38,36 @@ func (suite *UploadTestSuite) TestUploadWithFilenames() {
 	wg.Wait()
 }
 
+func (suite *UploadTestSuite) TestUploadWithDirectoryNames() {
+	reqCount := make(chan int, 100)
+	client, server := newClientAndTestServer(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(suite.T(), "PUT", r.Method)
+		reqCount <- 1
+	})
+	defer server.Close()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go upload(client, []string{"templates"}, &wg)
+	wg.Wait()
+	assert.Equal(suite.T(), 2, len(reqCount))
+}
+
+func (suite *UploadTestSuite) TestUploadWithBadFileNames() {
+	reqCount := make(chan int, 100)
+	client, server := newClientAndTestServer(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(suite.T(), "PUT", r.Method)
+		reqCount <- 1
+	})
+	defer server.Close()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go upload(client, []string{"templates/foo.liquid"}, &wg)
+	wg.Wait()
+	assert.Equal(suite.T(), 0, len(reqCount))
+}
+
 func (suite *UploadTestSuite) TestUploadAll() {
 	requests := map[string]string{}
 	client, server := newClientAndTestServer(func(w http.ResponseWriter, r *http.Request) {

--- a/kit/asset_test.go
+++ b/kit/asset_test.go
@@ -127,6 +127,12 @@ func (s *LoadAssetSuite) TestLoadAssetsFromDirectory() {
 	}}, assets)
 }
 
+func (s *LoadAssetSuite) TestLoadAssetsFromDirectoryWithSubdir() {
+	assets, err := loadAssetsFromDirectory(clean("../fixtures/project"), "assets", func(path string) bool { return false })
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), 2, len(assets))
+}
+
 func (s *LoadAssetSuite) TestLoadAsset() {
 	asset, err := loadAsset(clean("../fixtures/project"), clean("assets/application.js"))
 	assert.Equal(s.T(), "assets/application.js", asset.Key)
@@ -139,7 +145,7 @@ func (s *LoadAssetSuite) TestLoadAsset() {
 
 	asset, err = loadAsset(clean("../fixtures/project"), "templates")
 	assert.NotNil(s.T(), err)
-	assert.Equal(s.T(), "loadAsset: File is a directory", err.Error())
+	assert.Equal(s.T(), ErrAssetIsDir, err)
 
 	asset, err = loadAsset(clean("../fixtures/project"), "assets/pixel.png")
 	assert.Nil(s.T(), err)

--- a/kit/asset_test.go
+++ b/kit/asset_test.go
@@ -115,9 +115,9 @@ func (s *LoadAssetSuite) TestFindAllFiles() {
 }
 
 func (s *LoadAssetSuite) TestLoadAssetsFromDirectory() {
-	assets, err := loadAssetsFromDirectory(clean("../fixtures/project/valid_patterns"), func(path string) bool { return false })
+	assets, err := loadAssetsFromDirectory(clean("../fixtures/project/valid_patterns"), "", func(path string) bool { return false })
 	assert.Equal(s.T(), "Path is not a directory", err.Error())
-	assets, err = loadAssetsFromDirectory(clean("../fixtures/project"), func(path string) bool {
+	assets, err = loadAssetsFromDirectory(clean("../fixtures/project"), "", func(path string) bool {
 		return path != "assets/application.js"
 	})
 	assert.Nil(s.T(), err)

--- a/kit/theme_client.go
+++ b/kit/theme_client.go
@@ -65,7 +65,10 @@ func (t ThemeClient) Asset(filename string) (Asset, Error) {
 }
 
 // LocalAssets will return a slice of assets from the local disk. The
-// assets are filtered based on your config.
+// assets are filtered based on your config. If not paths are passed to
+// the function then all the local assets are returned. If you pass file names
+// those assets will be loaded. If any of the file paths are directories, all
+// of the directory's recursive assets will be returned.
 func (t ThemeClient) LocalAssets(paths ...string) (assets []Asset, err error) {
 	if paths == nil || len(paths) == 0 {
 		assets, err = loadAssetsFromDirectory(t.Config.Directory, "", t.filter.matchesFilter)

--- a/kit/theme_client_test.go
+++ b/kit/theme_client_test.go
@@ -85,7 +85,7 @@ func (suite *ThemeClientTestSuite) TestAsset() {
 	assert.Equal(suite.T(), "assets/hello.txt", asset.Key)
 }
 
-func (suite *ThemeClientTestSuite) TestLocalAssets() {
+func (suite *ThemeClientTestSuite) TestLocalAssetsWithoutFilenames() {
 	assets, err := suite.client.LocalAssets()
 	assert.Nil(suite.T(), err)
 	assert.Equal(suite.T(), 7, len(assets))
@@ -93,6 +93,12 @@ func (suite *ThemeClientTestSuite) TestLocalAssets() {
 	suite.client.Config.Directory = "./nope"
 	_, err = suite.client.LocalAssets()
 	assert.NotNil(suite.T(), err)
+}
+
+func (suite *ThemeClientTestSuite) TestLocalAssetsWithFilenames() {
+	assets, err := suite.client.LocalAssets("assets", "config/settings_data.json")
+	assert.Nil(suite.T(), err)
+	assert.Equal(suite.T(), 3, len(assets))
 }
 
 func (suite *ThemeClientTestSuite) TestLocalAsset() {


### PR DESCRIPTION
fixes #264 
fixes #310 

This adds the functionality to upload directories by calling `theme upload ./assets` or `theme upload assets` This will upload all the files recursively in the the directory. It also enables the user to download using wildcards like this: `theme download assets/*.js` 