### PR TITLE
python 3 fix

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -106,7 +106,7 @@ class Installer(object):
         dest.write(theme.read())
         dest.flush()
         dest.close()
-        os.chmod(filename, 0755)
+        os.chmod(filename, 0o755)
 
     def __pathinstall(self):
         print("Theme Kit has been installed at %s/theme" % self.installlocation)


### PR DESCRIPTION
Fix for https://github.com/Shopify/themekit/commit/9ae31714bc1a96af2f5703049538a45f989b983d#commitcomment-20733658

"0755 is not a valid numerical literal in python 3.5. If you change it to 0o755, it will be compatible with both 2.7 and 3.5. See: https://www.python.org/dev/peps/pep-3127"