### PR TITLE
Reload Watch on Config Change

### DIFF
--- a/cmd/remove_test.go
+++ b/cmd/remove_test.go
@@ -56,13 +56,17 @@ func TestRemoveTestSuite(t *testing.T) {
 	suite.Run(t, new(RemoveTestSuite))
 }
 
-func newClientAndTestServer(handler http.HandlerFunc) (kit.ThemeClient, *httptest.Server) {
-	server := httptest.NewServer(handler)
+func newTestClient(domain string) kit.ThemeClient {
 	config, _ := kit.NewConfiguration()
-	config.Domain = server.URL
+	config.Domain = domain
 	config.ThemeID = "123"
 	config.Password = "sharknado"
 	config.Directory = "../fixtures/project"
 	client, _ := kit.NewThemeClient(config)
-	return client, server
+	return client
+}
+
+func newClientAndTestServer(handler http.HandlerFunc) (kit.ThemeClient, *httptest.Server) {
+	server := httptest.NewServer(handler)
+	return newTestClient(server.URL), server
 }

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"os"
 	"os/signal"
 
@@ -9,7 +10,11 @@ import (
 	"github.com/Shopify/themekit/kit"
 )
 
-var signalChan = make(chan os.Signal)
+var (
+	signalChan   = make(chan os.Signal)
+	reloadSignal = make(chan bool)
+	errReload    = errors.New("Reload Watcher")
+)
 
 var watchCmd = &cobra.Command{
 	Use:   "watch",
@@ -21,12 +26,21 @@ run 'theme watch' while you are editing and it will detect create, update and de
 For more documentation please see http://shopify.github.io/themekit/commands/#watch
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		themeClients, err := generateThemeClients()
-		if err != nil {
-			return err
-		}
-		return watch(themeClients)
+		return startWatch()
 	},
+}
+
+func startWatch() error {
+	themeClients, err := generateThemeClients()
+	if err != nil {
+		return err
+	}
+	err = watch(themeClients)
+	if err == errReload {
+		kit.Print("Reloading because of config changes")
+		return startWatch()
+	}
+	return err
 }
 
 func watch(themeClients []kit.ThemeClient) error {
@@ -51,12 +65,20 @@ func watch(themeClients []kit.ThemeClient) error {
 		if err != nil {
 			return err
 		}
+		watcher.WatchConfig(configPath, reloadSignal)
+		if err != nil {
+			return err
+		}
 		watchers = append(watchers, watcher)
 	}
 
 	if len(watchers) > 0 {
 		signal.Notify(signalChan, os.Interrupt)
-		<-signalChan
+		select {
+		case <-signalChan:
+		case <-reloadSignal:
+			return errReload
+		}
 	}
 
 	return nil

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -49,7 +49,9 @@ func watch(themeClients []kit.ThemeClient) error {
 		if len(watchers) > 0 {
 			kit.Print("Cleaning up watchers")
 			for _, watcher := range watchers {
-				watcher.StopWatching()
+				// This is half assed because fsnotify sometimes deadlocks
+				// if it finishes before exit great if not garbage collection will do it.
+				go watcher.StopWatching()
 			}
 		}
 	}()

--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,12 @@
-hash: c066f2443936bdf20522f14889145c819416da3916789fdd293693264a330f65
-updated: 2017-01-23T12:18:18.012154506-05:00
+hash: d604ab3da870745bdfa628a3ec25836c23f47299872e5ebd2050813486bbf33a
+updated: 2017-02-03T15:52:47.09645985-05:00
 imports:
 - name: github.com/caarlos0/env
   version: d0de832ed2fbc4e7bfaa30ab5cf0b3417d15f529
 - name: github.com/fatih/color
   version: 34e4ee095d12986a2cef5ddb9aeb3b8cfcfea17c
+- name: github.com/fsnotify/fsnotify
+  version: 629574ca2a5df945712d3079857300b5e4da0236
 - name: github.com/hashicorp/go-version
   version: e96d3840402619007766590ecea8dd7af1292276
 - name: github.com/imdario/mergo

--- a/glide.yaml
+++ b/glide.yaml
@@ -6,14 +6,14 @@ import:
 - package: github.com/ryanuber/go-glob
   version: ^0.1.0
 - package: github.com/spf13/cobra
-- package: gopkg.in/fsnotify.v1
-  version: ^1.4.1
 - package: gopkg.in/yaml.v1
 - package: github.com/spf13/viper
 - package: github.com/caarlos0/env
   version: ^2.1.0
 - package: github.com/hashicorp/go-version
 - package: github.com/skratchdot/open-golang
+- package: github.com/fsnotify/fsnotify
+  version: ^1.4.2
 testImport:
 - package: github.com/stretchr/testify
   version: ^1.1.4

--- a/kit/file_watcher.go
+++ b/kit/file_watcher.go
@@ -108,7 +108,6 @@ func (watcher *FileWatcher) watchFsEvents(notifyFile string) {
 						select {
 						case event = <-eventChan:
 						case <-time.After(debounceTimeout):
-							println("event dogin", debounceTimeout)
 							go handleEvent(watcher, event)
 							eventLock.Lock()
 							delete(recordedEvents, eventName)

--- a/kit/file_watcher_test.go
+++ b/kit/file_watcher_test.go
@@ -103,12 +103,10 @@ func (suite *FileWatcherTestSuite) TestReloadConfig() {
 	configChan := make(chan fsnotify.Event)
 	reloadChan := make(chan bool, 100)
 
-	w, _ := fsnotify.NewWatcher()
-	w.Events = configChan
 	newWatcher := &FileWatcher{
 		done:          make(chan bool),
 		mainWatcher:   &fsnotify.Watcher{Events: make(chan fsnotify.Event)},
-		configWatcher: w,
+		configWatcher: &fsnotify.Watcher{Events: configChan},
 	}
 
 	newWatcher.callback = func(client ThemeClient, asset Asset, event EventType) {}

--- a/kit/file_watcher_test.go
+++ b/kit/file_watcher_test.go
@@ -103,10 +103,12 @@ func (suite *FileWatcherTestSuite) TestReloadConfig() {
 	configChan := make(chan fsnotify.Event)
 	reloadChan := make(chan bool, 100)
 
+	configWatcher, _ := fsnotify.NewWatcher()
+	configWatcher.Events = configChan
 	newWatcher := &FileWatcher{
 		done:          make(chan bool),
 		mainWatcher:   &fsnotify.Watcher{Events: make(chan fsnotify.Event)},
-		configWatcher: &fsnotify.Watcher{Events: configChan},
+		configWatcher: configWatcher,
 	}
 
 	newWatcher.callback = func(client ThemeClient, asset Asset, event EventType) {}

--- a/kit/file_watcher_test.go
+++ b/kit/file_watcher_test.go
@@ -38,9 +38,10 @@ func (suite *FileWatcherTestSuite) TestWatchFsEvents() {
 	filter, _ := newFileFilter(watchFixturePath, []string{}, []string{})
 
 	newWatcher := &FileWatcher{
-		done:    make(chan bool),
-		filter:  filter,
-		watcher: &fsnotify.Watcher{Events: eventChan},
+		done:          make(chan bool),
+		filter:        filter,
+		mainWatcher:   &fsnotify.Watcher{Events: eventChan},
+		configWatcher: &fsnotify.Watcher{Events: make(chan fsnotify.Event)},
 	}
 
 	newWatcher.callback = func(client ThemeClient, asset Asset, event EventType) {

--- a/kit/file_watcher_test.go
+++ b/kit/file_watcher_test.go
@@ -100,11 +100,9 @@ func (suite *FileWatcherTestSuite) TestWatchFsEvents() {
 }
 
 func (suite *FileWatcherTestSuite) TestReloadConfig() {
-	configChan := make(chan fsnotify.Event)
 	reloadChan := make(chan bool, 100)
 
 	configWatcher, _ := fsnotify.NewWatcher()
-	configWatcher.Events = configChan
 	newWatcher := &FileWatcher{
 		done:          make(chan bool),
 		mainWatcher:   &fsnotify.Watcher{Events: make(chan fsnotify.Event)},
@@ -116,7 +114,7 @@ func (suite *FileWatcherTestSuite) TestReloadConfig() {
 	assert.Nil(suite.T(), err)
 
 	go newWatcher.watchFsEvents("")
-	configChan <- fsnotify.Event{Name: goodEnvirontmentPath, Op: fsnotify.Write}
+	configWatcher.Events <- fsnotify.Event{Name: goodEnvirontmentPath, Op: fsnotify.Write}
 
 	assert.Equal(suite.T(), len(reloadChan), 1)
 	assert.Equal(suite.T(), newWatcher.IsWatching(), false)


### PR DESCRIPTION
fixes https://github.com/Shopify/themekit/issues/236

This will keep watch on the config file as a priority over any other file so that when it changes, all other events are stopped and watchers are reloaded.