### PR TITLE
Fixed file counts for single file uploads

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -53,7 +53,7 @@ func download(client kit.ThemeClient, filenames []string) error {
 		}
 	}
 
-	bar := newProgressBar(len(filenames)-1, client.Config.Environment)
+	bar := newProgressBar(len(filenames), client.Config.Environment)
 	for _, filename := range filenames {
 		wg.Add(1)
 		go downloadFile(client, filename, bar, &wg)

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -29,7 +29,7 @@ func remove(client kit.ThemeClient, filenames []string, wg *sync.WaitGroup) {
 		return
 	}
 
-	bar := newProgressBar(len(filenames)-1, client.Config.Environment)
+	bar := newProgressBar(len(filenames), client.Config.Environment)
 	for _, filename := range filenames {
 		wg.Add(1)
 		go performRemove(client, kit.Asset{Key: filename}, bar, wg)

--- a/cmd/replace.go
+++ b/cmd/replace.go
@@ -60,9 +60,10 @@ func replace(client kit.ThemeClient, filenames []string, wg *sync.WaitGroup) {
 		assetsActions[asset.Key] = assetAction{asset: asset, event: kit.Update}
 	}
 
-	bar := newProgressBar(len(assetsActions)-1, client.Config.Environment)
+	bar := newProgressBar(len(assetsActions), client.Config.Environment)
 	for key, action := range assetsActions {
 		if key == settingsDataKey {
+			incBar(bar) //pretend we did this one we will do it later
 			continue
 		}
 		wg.Add(1)

--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -37,9 +37,10 @@ func upload(client kit.ThemeClient, filenames []string, wg *sync.WaitGroup) {
 		return
 	}
 
-	bar := newProgressBar(len(localAssets)-2, client.Config.Environment)
+	bar := newProgressBar(len(localAssets), client.Config.Environment)
 	for _, asset := range localAssets {
 		if asset.Key == settingsDataKey {
+			incBar(bar) //pretend we did this one we will do it later
 			continue
 		}
 		wg.Add(1)


### PR DESCRIPTION
fixes #333 

The file counts were inaccurate. The count was having one taken away incorrectly. This PR makes better file counts.

The reason this happened is that file uploads and downloads were changed in a different PR outside of the progress bar work so it's work conflicted with this.