### PR TITLE
Adding handling in case the root directory is a symlink

### DIFF
--- a/fixtures/symlink_project
+++ b/fixtures/symlink_project
@@ -1,0 +1,1 @@
+./project

--- a/kit/file_watcher.go
+++ b/kit/file_watcher.go
@@ -57,7 +57,12 @@ func newFileWatcher(client ThemeClient, dir, notifyFile string, recur bool, filt
 }
 
 func (watcher *FileWatcher) watchDirectory(root string) error {
-	root = filepath.Clean(root)
+	var symlinkErr error
+	root, symlinkErr = filepath.EvalSymlinks(filepath.Clean(root))
+	if symlinkErr != nil {
+		return symlinkErr
+	}
+
 	return filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err

--- a/kit/file_watcher_test.go
+++ b/kit/file_watcher_test.go
@@ -13,8 +13,9 @@ import (
 )
 
 var (
-	textFixturePath  = filepath.Join("..", "fixtures", "project", "assets", "application.js")
-	watchFixturePath = filepath.Join("..", "fixtures", "project")
+	textFixturePath    = filepath.Join("..", "fixtures", "project", "assets", "application.js")
+	watchFixturePath   = filepath.Join("..", "fixtures", "project")
+	symlinkFixturePath = filepath.Join("..", "fixtures", "symlink_project")
 )
 
 type FileWatcherTestSuite struct {
@@ -29,18 +30,26 @@ func (suite *FileWatcherTestSuite) TestNewFileReader() {
 	watcher.StopWatching()
 }
 
-func (suite *FileWatcherTestSuite) WatchDirectory() {
-	eventChan := make(chan fsnotify.Event)
+func (suite *FileWatcherTestSuite) TestWatchDirectory() {
 	filter, _ := newFileFilter(watchFixturePath, []string{}, []string{})
+	w, _ := fsnotify.NewWatcher()
 	newWatcher := &FileWatcher{
-		done:        make(chan bool),
 		filter:      filter,
-		mainWatcher: &fsnotify.Watcher{Events: eventChan},
+		mainWatcher: w,
 	}
-
 	newWatcher.watchDirectory(watchFixturePath)
-	path, _ := filepath.Abs(textFixturePath)
-	assert.Nil(suite.T(), newWatcher.mainWatcher.Remove(path))
+	assert.Nil(suite.T(), newWatcher.mainWatcher.Remove(filepath.Join("..", "fixtures", "project", "assets")))
+}
+
+func (suite *FileWatcherTestSuite) TestWatchSymlinkDirectory() {
+	filter, _ := newFileFilter(symlinkFixturePath, []string{}, []string{})
+	w, _ := fsnotify.NewWatcher()
+	newWatcher := &FileWatcher{
+		filter:      filter,
+		mainWatcher: w,
+	}
+	newWatcher.watchDirectory(symlinkFixturePath)
+	assert.Nil(suite.T(), newWatcher.mainWatcher.Remove(filepath.Join("..", "fixtures", "project", "assets")))
 }
 
 func (suite *FileWatcherTestSuite) TestWatchConfig() {


### PR DESCRIPTION
fixes #336 

There was a problem with walking a directory that is a symlink. This resolves the symlink so that the directory can be walked correctly.