### PR TITLE
Added windows installer to the docs and NSIS install script

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -9,12 +9,13 @@
 
 # Pre-Requisites
 
-Run `make tools` to install all the tools except go.
+Run `make mac_tools` or `make linux_tools` to install all the tools except go.
 
 - [Go 1.7 or higher](https://golang.org/dl)
 - [Glide](https://github.com/Masterminds/glide)
 - [golint](https://github.com/golang/lint)
 - [jekyll](https://jekyllrb.com/docs/installation/)
+- makensis
 
 # Getting the Source Code
 
@@ -31,32 +32,29 @@ access to the theme command. Run `theme` to make sure it is installed.
 
 # Creating Releases
 
+- You will need to have a valid `.env` file with credentials for the Amazon account.
 - run `make check`
-- update version using [SemVer](http://semver.org/) prefixed with a v. (e.g. 'v0.5.0')
-  - update ThemeKitVersion in `kit/version.go`
-  - update themekitversion `docs/_config.yml`
-  - run `git tag <version> && git push origin --tags`
-    Any tags that are postfixed with `-beta` will not prompt users for update so if
-    you want to release to a small group please use this method.
-- Create a release using `make dist` this will:
-  - Create binaries for all supported platforms
-  - Upload to S3
-  - Update the [manifest file](https://shopify-themekit.s3.amazonaws.com/releases/all.json)
-  - Update the [latest release file](https://shopify-themekit.s3.amazonaws.com/releases/latest.json)
+- Update ThemeKitVersion in `kit/version.go`
+- run `git tag <version> && git push origin --tags`
+  Any tags that are postfixed with `-beta` will not prompt users for update so if
+  you want to release to a small group please use this method.
+- Create a release using `make dist`
 - On Github create a new release for the tag and take note of any relevant changes
   - Include a brief summary of all the changes
   - Include links to the Pull Requests that introduced these changes
   - Also upload the zipped binaries from `build/dist/` manually to Github so people can easily download them
 - Update the [documentation website](https://shopify.github.io/themekit/)
-  - run `gem install jekyll`
   - run `make serve_docs`
   - update any changes to the API
   - commit any changes
+- Update themekitversion in docs config `docs/_config.yml` to update the download links.
 - Update `themekit.rb` formula for homebrew on https://github.com/Shopify/homebrew-shopify
+  - run `make gen_sha` to generate the SHA256 for the darwin build
+  - update the link and sha in the homebrew formula
 
 # Authors
 
 - Chris Saunders <[https://github.com/csaunders](https://github.com/csaunders)>
 - Jakob Külzer <[Shopify](https://shopify.com)>
 - Chris Butcher <[Shopify](https://shopify.com)>
-- Tim Anema <[Shopify](https://shopify.com)>
+- Tim Anema <[https://github.com/tanema](https://github.com/tanema)>

--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,16 @@ build32:
 	@export GOARCH=386; $(MAKE) build;
 
 windows: ## Build binaries for Windows (32 and 64 bit)
-	@echo "building win-64" && export GOOS=windows; export EXT=.exe; $(MAKE) build64 && echo "win-64 build complete";
-	@echo "building win-32" && export GOOS=windows; export EXT=.exe; $(MAKE) build32 && echo "win-32 build complete";
+	@echo "building win-64" &&\
+		export GOOS=windows; export EXT=.exe; $(MAKE) build64 &&\
+		makensis ./scripts/themekitInstaller64.nsi > /dev/null &&\
+		mv ./scripts/themekit-setup-64.exe ./build/dist/windows-amd64 &&\
+		echo "win-64 build complete";
+	@echo "building win-32" &&\
+		export GOOS=windows; export EXT=.exe; $(MAKE) build32 &&\
+		makensis ./scripts/themekitInstaller32.nsi > /dev/null &&\
+		mv ./scripts/themekit-setup-32.exe ./build/dist/windows-386 &&\
+		echo "win-32 build complete";
 
 mac: ## Build binaries for Mac OS X (64 bit)
 	@echo "building darwin-64" && export GOOS=darwin; $(MAKE) build64 && echo "darwin-64 build complete";
@@ -52,10 +60,16 @@ gen_sha: ## Generate sha256 for a darwin build for usage with homebrew
 serve_docs: ## Start the dev server for the jekyll static site serving the theme kit docs.
 	@cd docs && jekyll serve
 
-tools: ## Installs tools required for developing theme kit
+tools:
 	@curl https://glide.sh/get | sh
 	@go get -u github.com/golang/lint/golint
 	@gem install jekyll
+
+linux_tools: tools ## Installs linux tools required for developing theme kit
+	@sudo apt-get install nsis
+
+mac_tools: tools ## Installs mac tools required for developing theme kit
+	@brew install makensis
 
 help:
 	@grep -E '^[a-zA-Z_0-9-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,7 @@ dependencies:
     - mkdir -p "$PROJECT_PATH"
     - mkdir "$GOPATH/bin"
     - rsync -azC --delete ./ "$PROJECT_PATH/"
-    - cd $PROJECT_PATH && make tools
+    - cd $PROJECT_PATH && make linux_tools
 test:
   pre:
     - cd $PROJECT_PATH && glide install

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,6 +34,12 @@ brew tap shopify/shopify
 brew install themekit
 ```
 
+### Windows Installer
+
+Download and run the installer:
+[windows-64](https://shopify-themekit.s3.amazonaws.com/{{ site.themekitversion }}/windows-amd64/theme-setup-64.exe)
+[windows-32](https://shopify-themekit.s3.amazonaws.com/{{ site.themekitversion }}/windows-386/theme-setup-32.exe)
+
 ### Manual Installation
 
 Download and unzip the latest release.
@@ -45,24 +51,6 @@ Download and unzip the latest release.
 | Windows| 32-bit       |  [download](https://github.com/Shopify/themekit/releases/download/{{ site.themekitversion }}/windows-386.zip)
 | Linux  | 64-bit       |  [download](https://github.com/Shopify/themekit/releases/download/{{ site.themekitversion }}/linux-amd64.zip)
 | Linux  | 32-bit       |  [download](https://github.com/Shopify/themekit/releases/download/{{ site.themekitversion }}/linux-386.zip)
-
-**For macOS or Linux run the following commands**
-
-```bash
-cp ~/Downloads/theme /usr/local/bin # install the command onto your path
-theme # test output of theme and make sure it is working
-```
-
-**For installing on Windows run the following commands**
-
-- Create a folder inside `C:\Program Files\` called `Theme Kit`
-- Copy the extracted program into `C:\Program Files\Theme Kit`
-- Navigate to `Control Panel > System and Security > System`. Another way to get there is to Right-Click on `My Computer` and choose the `properties` item
-- Look for the button or link called `Environment Variables`
-- In the second panel look for the item called `Path` and double-click on it. This should open a window with a text field that is overflowing with content.
-- Move your cursor all the way to the end and add the following: `;C:\Program Files\Theme Kit\`
-- Click `OK` until all the windows are gone.
-- To verify that Theme Kit has been installed, open `cmd.exe` and type in `theme`.
 
 ## Get API Access
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,8 +37,8 @@ brew install themekit
 ### Windows Installer
 
 Download and run the installer:
-[windows-64](https://shopify-themekit.s3.amazonaws.com/{{ site.themekitversion }}/windows-amd64/theme-setup-64.exe)
-[windows-32](https://shopify-themekit.s3.amazonaws.com/{{ site.themekitversion }}/windows-386/theme-setup-32.exe)
+[windows-64](https://shopify-themekit.s3.amazonaws.com/{{ site.themekitversion }}/windows-amd64-installer/theme-setup-64.exe)
+[windows-32](https://shopify-themekit.s3.amazonaws.com/{{ site.themekitversion }}/windows-386-installer/theme-setup-32.exe)
 
 ### Manual Installation
 

--- a/scripts/EnvVarUpdate.nsh
+++ b/scripts/EnvVarUpdate.nsh
@@ -1,0 +1,327 @@
+/**
+ *  EnvVarUpdate.nsh
+ *    : Environmental Variables: append, prepend, and remove entries
+ *
+ *     WARNING: If you use StrFunc.nsh header then include it before this file
+ *              with all required definitions. This is to avoid conflicts
+ *
+ *  Usage:
+ *    ${EnvVarUpdate} "ResultVar" "EnvVarName" "Action" "RegLoc" "PathString"
+ *
+ *  Credits:
+ *  Version 1.0 
+ *  * Cal Turney (turnec2)
+ *  * Amir Szekely (KiCHiK) and e-circ for developing the forerunners of this
+ *    function: AddToPath, un.RemoveFromPath, AddToEnvVar, un.RemoveFromEnvVar,
+ *    WriteEnvStr, and un.DeleteEnvStr
+ *  * Diego Pedroso (deguix) for StrTok
+ *  * Kevin English (kenglish_hi) for StrContains
+ *  * Hendri Adriaens (Smile2Me), Diego Pedroso (deguix), and Dan Fuhry  
+ *    (dandaman32) for StrReplace
+ *
+ *  Version 1.1 (compatibility with StrFunc.nsh)
+ *  * techtonik
+ *
+ *  http://nsis.sourceforge.net/Environmental_Variables:_append%2C_prepend%2C_and_remove_entries
+ *
+ */
+
+
+!ifndef ENVVARUPDATE_FUNCTION
+!define ENVVARUPDATE_FUNCTION
+!verbose push
+!verbose 3
+!include "LogicLib.nsh"
+!include "WinMessages.NSH"
+!include "StrFunc.nsh"
+
+; ---- Fix for conflict if StrFunc.nsh is already includes in main file -----------------------
+!macro _IncludeStrFunction StrFuncName
+  !ifndef ${StrFuncName}_INCLUDED
+    ${${StrFuncName}}
+  !endif
+  !ifndef Un${StrFuncName}_INCLUDED
+    ${Un${StrFuncName}}
+  !endif
+  !define un.${StrFuncName} "${Un${StrFuncName}}"
+!macroend
+
+!insertmacro _IncludeStrFunction StrTok
+!insertmacro _IncludeStrFunction StrStr
+!insertmacro _IncludeStrFunction StrRep
+
+; ---------------------------------- Macro Definitions ----------------------------------------
+!macro _EnvVarUpdateConstructor ResultVar EnvVarName Action Regloc PathString
+  Push "${EnvVarName}"
+  Push "${Action}"
+  Push "${RegLoc}"
+  Push "${PathString}"
+    Call EnvVarUpdate
+  Pop "${ResultVar}"
+!macroend
+!define EnvVarUpdate '!insertmacro "_EnvVarUpdateConstructor"'
+ 
+!macro _unEnvVarUpdateConstructor ResultVar EnvVarName Action Regloc PathString
+  Push "${EnvVarName}"
+  Push "${Action}"
+  Push "${RegLoc}"
+  Push "${PathString}"
+    Call un.EnvVarUpdate
+  Pop "${ResultVar}"
+!macroend
+!define un.EnvVarUpdate '!insertmacro "_unEnvVarUpdateConstructor"'
+; ---------------------------------- Macro Definitions end-------------------------------------
+ 
+;----------------------------------- EnvVarUpdate start----------------------------------------
+!define hklm_all_users     'HKLM "SYSTEM\CurrentControlSet\Control\Session Manager\Environment"'
+!define hkcu_current_user  'HKCU "Environment"'
+ 
+!macro EnvVarUpdate UN
+ 
+Function ${UN}EnvVarUpdate
+ 
+  Push $0
+  Exch 4
+  Exch $1
+  Exch 3
+  Exch $2
+  Exch 2
+  Exch $3
+  Exch
+  Exch $4
+  Push $5
+  Push $6
+  Push $7
+  Push $8
+  Push $9
+  Push $R0
+ 
+  /* After this point:
+  -------------------------
+     $0 = ResultVar     (returned)
+     $1 = EnvVarName    (input)
+     $2 = Action        (input)
+     $3 = RegLoc        (input)
+     $4 = PathString    (input)
+     $5 = Orig EnvVar   (read from registry)
+     $6 = Len of $0     (temp)
+     $7 = tempstr1      (temp)
+     $8 = Entry counter (temp)
+     $9 = tempstr2      (temp)
+     $R0 = tempChar     (temp)  */
+ 
+  ; Step 1:  Read contents of EnvVarName from RegLoc
+  ;
+  ; Check for empty EnvVarName
+  ${If} $1 == ""
+    SetErrors
+    DetailPrint "ERROR: EnvVarName is blank"
+    Goto EnvVarUpdate_Restore_Vars
+  ${EndIf}
+ 
+  ; Check for valid Action
+  ${If}    $2 != "A"
+  ${AndIf} $2 != "P"
+  ${AndIf} $2 != "R"
+    SetErrors
+    DetailPrint "ERROR: Invalid Action - must be A, P, or R"
+    Goto EnvVarUpdate_Restore_Vars
+  ${EndIf}
+ 
+  ${If} $3 == HKLM
+    ReadRegStr $5 ${hklm_all_users} $1     ; Get EnvVarName from all users into $5
+  ${ElseIf} $3 == HKCU
+    ReadRegStr $5 ${hkcu_current_user} $1  ; Read EnvVarName from current user into $5
+  ${Else}
+    SetErrors
+    DetailPrint 'ERROR: Action is [$3] but must be "HKLM" or HKCU"'
+    Goto EnvVarUpdate_Restore_Vars
+  ${EndIf}
+ 
+  ; Check for empty PathString
+  ${If} $4 == ""
+    SetErrors
+    DetailPrint "ERROR: PathString is blank"
+    Goto EnvVarUpdate_Restore_Vars
+  ${EndIf}
+ 
+  ; Make sure we've got some work to do
+  ${If} $5 == ""
+  ${AndIf} $2 == "R"
+    SetErrors
+    DetailPrint "$1 is empty - Nothing to remove"
+    Goto EnvVarUpdate_Restore_Vars
+  ${EndIf}
+ 
+  ; Step 2: Scrub EnvVar
+  ;
+  StrCpy $0 $5                             ; Copy the contents to $0
+  ; Remove spaces around semicolons (NOTE: spaces before the 1st entry or
+  ; after the last one are not removed here but instead in Step 3)
+  ${If} $0 != ""                           ; If EnvVar is not empty ...
+    ${Do}
+      ${${UN}StrStr} $7 $0 " ;"
+      ${If} $7 == ""
+        ${ExitDo}
+      ${EndIf}
+      ${${UN}StrRep} $0  $0 " ;" ";"         ; Remove '<space>;'
+    ${Loop}
+    ${Do}
+      ${${UN}StrStr} $7 $0 "; "
+      ${If} $7 == ""
+        ${ExitDo}
+      ${EndIf}
+      ${${UN}StrRep} $0  $0 "; " ";"         ; Remove ';<space>'
+    ${Loop}
+    ${Do}
+      ${${UN}StrStr} $7 $0 ";;" 
+      ${If} $7 == ""
+        ${ExitDo}
+      ${EndIf}
+      ${${UN}StrRep} $0  $0 ";;" ";"
+    ${Loop}
+ 
+    ; Remove a leading or trailing semicolon from EnvVar
+    StrCpy  $7  $0 1 0
+    ${If} $7 == ";"
+      StrCpy $0  $0 "" 1                   ; Change ';<EnvVar>' to '<EnvVar>'
+    ${EndIf}
+    StrLen $6 $0
+    IntOp $6 $6 - 1
+    StrCpy $7  $0 1 $6
+    ${If} $7 == ";"
+     StrCpy $0  $0 $6                      ; Change ';<EnvVar>' to '<EnvVar>'
+    ${EndIf}
+    ; DetailPrint "Scrubbed $1: [$0]"      ; Uncomment to debug
+  ${EndIf}
+ 
+  /* Step 3. Remove all instances of the target path/string (even if "A" or "P")
+     $6 = bool flag (1 = found and removed PathString)
+     $7 = a string (e.g. path) delimited by semicolon(s)
+     $8 = entry counter starting at 0
+     $9 = copy of $0
+     $R0 = tempChar      */
+ 
+  ${If} $5 != ""                           ; If EnvVar is not empty ...
+    StrCpy $9 $0
+    StrCpy $0 ""
+    StrCpy $8 0
+    StrCpy $6 0
+ 
+    ${Do}
+      ${${UN}StrTok} $7 $9 ";" $8 "0"      ; $7 = next entry, $8 = entry counter
+ 
+      ${If} $7 == ""                       ; If we've run out of entries,
+        ${ExitDo}                          ;    were done
+      ${EndIf}                             ;
+ 
+      ; Remove leading and trailing spaces from this entry (critical step for Action=Remove)
+      ${Do}
+        StrCpy $R0  $7 1
+        ${If} $R0 != " "
+          ${ExitDo}
+        ${EndIf}
+        StrCpy $7   $7 "" 1                ;  Remove leading space
+      ${Loop}
+      ${Do}
+        StrCpy $R0  $7 1 -1
+        ${If} $R0 != " "
+          ${ExitDo}
+        ${EndIf}
+        StrCpy $7   $7 -1                  ;  Remove trailing space
+      ${Loop}
+      ${If} $7 == $4                       ; If string matches, remove it by not appending it
+        StrCpy $6 1                        ; Set 'found' flag
+      ${ElseIf} $7 != $4                   ; If string does NOT match
+      ${AndIf}  $0 == ""                   ;    and the 1st string being added to $0,
+        StrCpy $0 $7                       ;    copy it to $0 without a prepended semicolon
+      ${ElseIf} $7 != $4                   ; If string does NOT match
+      ${AndIf}  $0 != ""                   ;    and this is NOT the 1st string to be added to $0,
+        StrCpy $0 $0;$7                    ;    append path to $0 with a prepended semicolon
+      ${EndIf}                             ;
+ 
+      IntOp $8 $8 + 1                      ; Bump counter
+    ${Loop}                                ; Check for duplicates until we run out of paths
+  ${EndIf}
+ 
+  ; Step 4:  Perform the requested Action
+  ;
+  ${If} $2 != "R"                          ; If Append or Prepend
+    ${If} $6 == 1                          ; And if we found the target
+      DetailPrint "Target is already present in $1. It will be removed and"
+    ${EndIf}
+    ${If} $0 == ""                         ; If EnvVar is (now) empty
+      StrCpy $0 $4                         ;   just copy PathString to EnvVar
+      ${If} $6 == 0                        ; If found flag is either 0
+      ${OrIf} $6 == ""                     ; or blank (if EnvVarName is empty)
+        DetailPrint "$1 was empty and has been updated with the target"
+      ${EndIf}
+    ${ElseIf} $2 == "A"                    ;  If Append (and EnvVar is not empty),
+      StrCpy $0 $0;$4                      ;     append PathString
+      ${If} $6 == 1
+        DetailPrint "appended to $1"
+      ${Else}
+        DetailPrint "Target was appended to $1"
+      ${EndIf}
+    ${Else}                                ;  If Prepend (and EnvVar is not empty),
+      StrCpy $0 $4;$0                      ;     prepend PathString
+      ${If} $6 == 1
+        DetailPrint "prepended to $1"
+      ${Else}
+        DetailPrint "Target was prepended to $1"
+      ${EndIf}
+    ${EndIf}
+  ${Else}                                  ; If Action = Remove
+    ${If} $6 == 1                          ;   and we found the target
+      DetailPrint "Target was found and removed from $1"
+    ${Else}
+      DetailPrint "Target was NOT found in $1 (nothing to remove)"
+    ${EndIf}
+    ${If} $0 == ""
+      DetailPrint "$1 is now empty"
+    ${EndIf}
+  ${EndIf}
+ 
+  ; Step 5:  Update the registry at RegLoc with the updated EnvVar and announce the change
+  ;
+  ClearErrors
+  ${If} $3  == HKLM
+    WriteRegExpandStr ${hklm_all_users} $1 $0     ; Write it in all users section
+  ${ElseIf} $3 == HKCU
+    WriteRegExpandStr ${hkcu_current_user} $1 $0  ; Write it to current user section
+  ${EndIf}
+ 
+  IfErrors 0 +4
+    MessageBox MB_OK|MB_ICONEXCLAMATION "Could not write updated $1 to $3"
+    DetailPrint "Could not write updated $1 to $3"
+    Goto EnvVarUpdate_Restore_Vars
+ 
+  ; "Export" our change
+  SendMessage ${HWND_BROADCAST} ${WM_WININICHANGE} 0 "STR:Environment" /TIMEOUT=5000
+ 
+  EnvVarUpdate_Restore_Vars:
+  ;
+  ; Restore the user's variables and return ResultVar
+  Pop $R0
+  Pop $9
+  Pop $8
+  Pop $7
+  Pop $6
+  Pop $5
+  Pop $4
+  Pop $3
+  Pop $2
+  Pop $1
+  Push $0  ; Push my $0 (ResultVar)
+  Exch
+  Pop $0   ; Restore his $0
+ 
+FunctionEnd
+ 
+!macroend   ; EnvVarUpdate UN
+!insertmacro EnvVarUpdate ""
+!insertmacro EnvVarUpdate "un."
+;----------------------------------- EnvVarUpdate end----------------------------------------
+ 
+!verbose pop
+!endif

--- a/scripts/release
+++ b/scripts/release
@@ -147,7 +147,7 @@ class ReleaseGenerator
       build_location = File.expand_path(DIST_DIR + "/#{platform}")
       installer = Dir.entries(build_location).find { |name| name =~ /themekit-setup/ }
       unless installer.nil?
-        Release.new(version: version, platform: platform, filename: [build_location, installer].join('/'))
+        Release.new(version: version, platform: "#{platform}-installer", filename: [build_location, installer].join('/'))
       end
     end.compact
   end

--- a/scripts/release
+++ b/scripts/release
@@ -95,7 +95,13 @@ class Release
     }
   end
 
+  def upload storage_manager
+    storage_manager.upload!(full_name, data)
+    location = storage_manager.url(full_name)
+  end
+
   private
+
   def load_file(filename)
     file = File.open(filename, 'rb')
     @full_name = [version, platform, File.basename(file.path)].join('/')
@@ -105,7 +111,7 @@ class Release
 end
 
 class ReleaseGenerator
-  attr_reader :version, :releases, :storage_manager
+  attr_reader :version, :storage_manager
 
   DIST_DIR = File.expand_path(__FILE__ + "/../../build/dist")
   BUILDS = %w(darwin-amd64 linux-386 linux-amd64 windows-386 windows-amd64)
@@ -113,7 +119,6 @@ class ReleaseGenerator
   def initialize(version, storage_manager)
     ensure_builds_have_been_created
     @version = version
-    @releases = prepare_releases
     @storage_manager = storage_manager
   end
 
@@ -121,9 +126,30 @@ class ReleaseGenerator
     ensure_release_is_necessary
     releases.each do |release|
       logger.puts "  - Uploading #{release.full_name}" if logger
-      storage_manager.upload!(release.full_name, release.data)
-      release.location = storage_manager.url(release.full_name)
+      release.upload(storage_manager)
     end
+    installers.each do |release|
+      logger.puts "  - Uploading #{release.full_name}" if logger
+      release.upload(storage_manager)
+    end
+  end
+
+  def releases
+    @releases ||= BUILDS.map do |platform|
+      build_location = File.expand_path(DIST_DIR + "/#{platform}")
+      binary = Dir.entries(build_location).find { |name| name =~ /theme/ }
+      Release.new(version: version, platform: platform, filename: [build_location, binary].join('/'))
+    end
+  end
+
+  def installers
+    @installers ||= BUILDS.map do |platform|
+      build_location = File.expand_path(DIST_DIR + "/#{platform}")
+      installer = Dir.entries(build_location).find { |name| name =~ /themekit-setup/ }
+      unless installer.nil?
+        Release.new(version: version, platform: platform, filename: [build_location, installer].join('/'))
+      end
+    end.compact
   end
 
   private
@@ -139,19 +165,6 @@ class ReleaseGenerator
     if feed.find { |r| r['version'] == version }
       puts "v#{version} has already been deployed. If this was intended to be a new release, ensure version.go has been updated and add an appropriate tag to git"
       exit(1)
-    end
-  end
-
-  def prepare_releases
-    BUILDS.map do |platform|
-      build_location = File.expand_path(DIST_DIR + "/#{platform}")
-      binary = Dir.entries(build_location).find { |name| name =~ /theme/ }
-      Release.new(version: version, platform: platform, filename: [build_location, binary].join('/'))
-
-      installer = Dir.entries(build_location).find { |name| name =~ /themekit-setup/ }
-      unless installer.nil?
-        Release.new(version: version, platform: platform, filename: [build_location, installer].join('/'))
-      end
     end
   end
 end

--- a/scripts/release
+++ b/scripts/release
@@ -147,6 +147,11 @@ class ReleaseGenerator
       build_location = File.expand_path(DIST_DIR + "/#{platform}")
       binary = Dir.entries(build_location).find { |name| name =~ /theme/ }
       Release.new(version: version, platform: platform, filename: [build_location, binary].join('/'))
+
+      installer = Dir.entries(build_location).find { |name| name =~ /themekit-setup/ }
+      unless installer.nil?
+        Release.new(version: version, platform: platform, filename: [build_location, installer].join('/'))
+      end
     end
   end
 end

--- a/scripts/themekitInstaller32.nsi
+++ b/scripts/themekitInstaller32.nsi
@@ -1,0 +1,9 @@
+!include "EnvVarUpdate.nsh"
+Name 'Shopify Theme Kit 32 Bit'
+OutFile 'themekit-setup-32.exe'
+InstallDir $PROGRAMFILES\themekit
+Section "Install"
+  SetOutPath $INSTDIR
+  File ../build/dist/windows-386/theme.exe
+  ${EnvVarUpdate} $0 "PATH" "A" "HKCU" $INSTDIR
+SectionEnd

--- a/scripts/themekitInstaller64.nsi
+++ b/scripts/themekitInstaller64.nsi
@@ -1,0 +1,9 @@
+!include "EnvVarUpdate.nsh"
+Name 'Shopify Theme Kit 64 Bit'
+OutFile 'themekit-setup-64.exe'
+InstallDir $PROGRAMFILES\themekit
+Section "Install"
+  SetOutPath $INSTDIR
+  File ../build/dist/windows-amd64/theme.exe
+  ${EnvVarUpdate} $0 "PATH" "A" "HKCU" $INSTDIR
+SectionEnd


### PR DESCRIPTION
fixes #146 I think once there is a proper windows installation all platforms will be covered. There is no reason to make a Debian package for a single binary package.

This adds windows installer functionality so that windows users don't have to edit environment variables. This will automatically put the binary into the `C:\Program Files\themekit` directory then put that directory into the users PATH variable. It is also now streamlined into the distribution workflow so that the user just needs to have `makensis` installed and they don't need to know how to build the windows installer.