### PR TITLE
Taking out all the extra sorting code fort sort.Slice in go1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Please find further usage instructions on the [theme kit website](https://shopif
 
 # Development
 
-You can setup your development environment by running the following:
+Themekit requires go 1.8. You can setup your development environment by running
+the following:
 
 ```bash
 go get -u github.com/Shopify/themekit

--- a/circle.yml
+++ b/circle.yml
@@ -4,13 +4,20 @@ machine:
     IMPORT_PATH: "github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"
     PROJECT_PATH: "$GOPATH/src/$IMPORT_PATH"
     PATH: "$PATH:$GOPATH/bin"
+    GODIST: "go1.8.linux-amd64.tar.gz"
+  post:
+    - mkdir -p download
+    - test -e download/$GODIST || curl -o download/$GODIST https://storage.googleapis.com/golang/$GODIST
+    - sudo rm -rf /usr/local/go
+    - sudo tar -C /usr/local -xzf download/$GODIST
 
 dependencies:
   override:
     - mkdir -p "$PROJECT_PATH"
     - mkdir "$GOPATH/bin"
     - rsync -azC --delete ./ "$PROJECT_PATH/"
-    - cd $PROJECT_PATH && make linux_tools
+    - curl https://glide.sh/get | sh
+    - go get -u github.com/golang/lint/golint
 test:
   pre:
     - cd $PROJECT_PATH && glide install

--- a/kit/asset.go
+++ b/kit/asset.go
@@ -87,24 +87,6 @@ func (asset Asset) Contents() ([]byte, error) {
 	return data, nil
 }
 
-// ByAsset implements sort.Interface for sorting remote assets
-type ByAsset []Asset
-
-// Len returns the length of the array.
-func (assets ByAsset) Len() int {
-	return len(assets)
-}
-
-// Swap swaps two values in the slive
-func (assets ByAsset) Swap(i, j int) {
-	assets[i], assets[j] = assets[j], assets[i]
-}
-
-// Less is the comparison method. Will return true if the first is less than the second.
-func (assets ByAsset) Less(i, j int) bool {
-	return assets[i].Key < assets[j].Key
-}
-
 func findAllFiles(dir string) ([]string, error) {
 	var files []string
 

--- a/kit/asset_test.go
+++ b/kit/asset_test.go
@@ -3,7 +3,6 @@ package kit
 import (
 	"encoding/base64"
 	"os"
-	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -71,25 +70,6 @@ func (s *LoadAssetSuite) TestContents() {
 	assert.Equal(s.T(), `{
   "test": "one"
 }`, string(data))
-}
-
-func (s *LoadAssetSuite) TestAssetsSort() {
-	input := []Asset{
-		{Key: "assets/ajaxify.js.liquid"},
-		{Key: "assets/ajaxify.js"},
-		{Key: "assets/ajaxify.css"},
-		{Key: "assets/ajaxify.css.liquid"},
-		{Key: "layouts/customers.liquid"},
-	}
-	expected := []Asset{
-		{Key: "assets/ajaxify.css"},
-		{Key: "assets/ajaxify.css.liquid"},
-		{Key: "assets/ajaxify.js"},
-		{Key: "assets/ajaxify.js.liquid"},
-		{Key: "layouts/customers.liquid"},
-	}
-	sort.Sort(ByAsset(input))
-	assert.Equal(s.T(), expected, input)
 }
 
 func (s *LoadAssetSuite) TestFindAllFiles() {

--- a/kit/file_filter.go
+++ b/kit/file_filter.go
@@ -90,7 +90,7 @@ func newFileFilter(rootDir string, patterns []string, files []string) (fileFilte
 // will filter the first asset (`app.js`) from the slice.
 func (e fileFilter) filterAssets(assets []Asset) []Asset {
 	filteredAssets := []Asset{}
-	sort.Sort(ByAsset(assets))
+	sort.Slice(assets, func(i, j int) bool { return assets[i].Key < assets[j].Key })
 	for index, asset := range assets {
 		if !e.matchesFilter(asset.Key) &&
 			(index == len(assets)-1 || assets[index+1].Key != asset.Key+".liquid") {

--- a/kit/release.go
+++ b/kit/release.go
@@ -49,7 +49,11 @@ func (r release) ForCurrentPlatform() platform {
 type releasesList []release
 
 func (releases releasesList) Get(ver string) release {
-	sort.Sort(releases)
+	sort.Slice(releases, func(i, j int) bool {
+		iversion, _ := version.NewVersion(releases[i].Version)
+		jversion, _ := version.NewVersion(releases[j].Version)
+		return jversion.LessThan(iversion)
+	})
 	if ver == "latest" {
 		return releases[0]
 	}
@@ -61,18 +65,4 @@ func (releases releasesList) Get(ver string) release {
 		}
 	}
 	return release{}
-}
-
-func (releases releasesList) Len() int {
-	return len(releases)
-}
-
-func (releases releasesList) Swap(i, j int) {
-	releases[i], releases[j] = releases[j], releases[i]
-}
-
-func (releases releasesList) Less(i, j int) bool {
-	iversion, _ := version.NewVersion(releases[i].Version)
-	jversion, _ := version.NewVersion(releases[j].Version)
-	return jversion.LessThan(iversion)
 }

--- a/kit/release_test.go
+++ b/kit/release_test.go
@@ -82,30 +82,3 @@ func TestReleasesListGet(t *testing.T) {
 	assert.Equal(t, "", r.Version)
 	assert.Equal(t, false, r.IsValid())
 }
-
-func TestReleasesListLen(t *testing.T) {
-	var releases releasesList
-	resp := jsonFixture("responses/all_releases")
-	json.Unmarshal([]byte(resp), &releases)
-	assert.Equal(t, 4, releases.Len())
-}
-
-func TestReleasesListSwap(t *testing.T) {
-	var releases releasesList
-	resp := jsonFixture("responses/all_releases")
-	json.Unmarshal([]byte(resp), &releases)
-
-	assert.Equal(t, "0.4.4", releases[0].Version)
-	assert.Equal(t, "0.4.7", releases[1].Version)
-	releases.Swap(0, 1)
-	assert.Equal(t, "0.4.4", releases[1].Version)
-	assert.Equal(t, "0.4.7", releases[0].Version)
-}
-
-func TestReleasesListLess(t *testing.T) {
-	var releases releasesList
-	resp := jsonFixture("responses/all_releases")
-	json.Unmarshal([]byte(resp), &releases)
-	assert.Equal(t, false, releases.Less(0, 1))
-	assert.Equal(t, true, releases.Less(1, 2))
-}

--- a/kit/theme_client_test.go
+++ b/kit/theme_client_test.go
@@ -66,7 +66,9 @@ func (suite *ThemeClientTestSuite) TestAssetList() {
 	expected := map[string][]Asset{}
 	bytes := []byte(jsonFixture("responses/assets_filtered"))
 	json.Unmarshal(bytes, &expected)
-	sort.Sort(ByAsset(expected["assets"]))
+	sort.Slice(expected["assets"], func(i, j int) bool {
+		return expected["assets"][i].Key < expected["assets"][j].Key
+	})
 
 	assets, err := suite.client.AssetList()
 	assert.Nil(suite.T(), err)


### PR DESCRIPTION
Go 1.8 introduced a new sorting mechanic so that I could take out a lot of sorting code. It really cleans stuff up.