### PR TITLE
Refactoring watch for performance

### DIFF
--- a/kit/event_map.go
+++ b/kit/event_map.go
@@ -1,0 +1,50 @@
+package kit
+
+import (
+	"sync"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+type eventMap struct {
+	sync.RWMutex
+	events map[string]chan fsnotify.Event
+}
+
+func newEventMap() *eventMap {
+	return &eventMap{
+		events: map[string]chan fsnotify.Event{},
+	}
+}
+
+func (em *eventMap) Get(eventName string) (chan fsnotify.Event, bool) {
+	em.RLock()
+	defer em.RUnlock()
+	eventsChan, ok := em.events[eventName]
+	return eventsChan, ok
+}
+
+func (em *eventMap) Del(eventName string) {
+	em.Lock()
+	defer em.Unlock()
+	delete(em.events, eventName)
+}
+
+func (em *eventMap) Count() int {
+	em.RLock()
+	defer em.RUnlock()
+	return len(em.events)
+}
+
+func (em *eventMap) Set(eventName string, eventsChan chan fsnotify.Event) {
+	em.Lock()
+	defer em.Unlock()
+	em.events[eventName] = eventsChan
+}
+
+func (em *eventMap) New(eventName string) chan fsnotify.Event {
+	em.Lock()
+	defer em.Unlock()
+	em.events[eventName] = make(chan fsnotify.Event)
+	return em.events[eventName]
+}

--- a/kit/event_map.go
+++ b/kit/event_map.go
@@ -43,8 +43,7 @@ func (em *eventMap) Set(eventName string, eventsChan chan fsnotify.Event) {
 }
 
 func (em *eventMap) New(eventName string) chan fsnotify.Event {
-	em.Lock()
-	defer em.Unlock()
-	em.events[eventName] = make(chan fsnotify.Event)
-	return em.events[eventName]
+	eventsChan := make(chan fsnotify.Event)
+	em.Set(eventName, eventsChan)
+	return eventsChan
 }

--- a/kit/event_map_test.go
+++ b/kit/event_map_test.go
@@ -1,0 +1,62 @@
+package kit
+
+import (
+	"testing"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type EventMapTestSuite struct {
+	suite.Suite
+}
+
+func (suite *EventMapTestSuite) TestGet() {
+	eventMap := newEventMap()
+	eventMap.New("test")
+	_, ok := eventMap.Get("test")
+	assert.True(suite.T(), ok)
+	_, ok = eventMap.Get("nope")
+	assert.False(suite.T(), ok)
+}
+
+func (suite *EventMapTestSuite) TestDel() {
+	eventMap := newEventMap()
+	eventMap.New("test")
+	_, ok := eventMap.Get("test")
+	assert.True(suite.T(), ok)
+	eventMap.Del("test")
+	_, ok = eventMap.Get("test")
+	assert.False(suite.T(), ok)
+}
+
+func (suite *EventMapTestSuite) TestCount() {
+	eventMap := newEventMap()
+	eventMap.New("test")
+	eventMap.New("test2")
+	eventMap.New("test")
+	eventMap.New("test3")
+	assert.Equal(suite.T(), eventMap.Count(), 3)
+}
+
+func (suite *EventMapTestSuite) TestSet() {
+	eventMap := newEventMap()
+	myChan := make(chan fsnotify.Event)
+	eventMap.Set("test", myChan)
+	assert.Equal(suite.T(), eventMap.Count(), 1)
+	getChan, _ := eventMap.Get("test")
+	assert.Equal(suite.T(), getChan, myChan)
+}
+
+func (suite *EventMapTestSuite) TestNew() {
+	eventMap := newEventMap()
+	myChan := eventMap.New("test")
+	assert.Equal(suite.T(), eventMap.Count(), 1)
+	getChan, _ := eventMap.Get("test")
+	assert.Equal(suite.T(), getChan, myChan)
+}
+
+func TestEventMapTestSuite(t *testing.T) {
+	suite.Run(t, new(EventMapTestSuite))
+}

--- a/kit/file_watcher.go
+++ b/kit/file_watcher.go
@@ -149,7 +149,7 @@ func (watcher *FileWatcher) onEvent(event fsnotify.Event) {
 }
 
 func (watcher *FileWatcher) watchForIdle() {
-	if watcher.waitNotify {
+	if watcher.waitNotify || watcher.notify == "" {
 		return
 	}
 	watcher.waitNotify = true
@@ -157,11 +157,10 @@ func (watcher *FileWatcher) watchForIdle() {
 		for {
 			select {
 			case <-time.Tick(debounceTimeout):
-				if watcher.recordedEvents.Count() > 0 || watcher.notify == "" {
-					break
+				if watcher.recordedEvents.Count() == 0 {
+					watcher.touchNotifyFile()
+					return
 				}
-				watcher.touchNotifyFile()
-				return
 			}
 		}
 	}()

--- a/kit/file_watcher_test.go
+++ b/kit/file_watcher_test.go
@@ -170,7 +170,6 @@ func (suite *FileWatcherTestSuite) TestOnEvent() {
 	assert.Equal(suite.T(), newWatcher.recordedEvents.Count(), 0)
 	newWatcher.onEvent(event1)
 	assert.Equal(suite.T(), newWatcher.recordedEvents.Count(), 1)
-	assert.True(suite.T(), newWatcher.waitNotify)
 	newWatcher.onEvent(event1)
 	assert.Equal(suite.T(), newWatcher.recordedEvents.Count(), 1)
 	newWatcher.onEvent(event2)


### PR DESCRIPTION
fixes #349 

After I refactored the watching event loop so that I could more accurately profile the cpu usage actually went down to peak 7%. This could be because I have moved a large amount of variables from anonymous functions into the watcher struct. This could the GC less like to take longer in figuring out if the variables are needed or not. This is only a guess because I am still not quite able to figure out what was causing the performance issues.