### PR TITLE
Added minimal vcs integration for branch changing

### DIFF
--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -67,7 +67,7 @@ func watch(themeClients []kit.ThemeClient) error {
 		if err != nil {
 			return err
 		}
-		watcher.WatchConfig(configPath, reloadSignal)
+		err = watcher.WatchConfig(configPath, reloadSignal)
 		if err != nil {
 			return err
 		}

--- a/kit/file_watcher.go
+++ b/kit/file_watcher.go
@@ -141,9 +141,22 @@ func (watcher *FileWatcher) watchFsEvents(notifyFile string) {
 // the channel to notify you about a config file change. This is useful to keep
 // track of version control changes
 func (watcher *FileWatcher) WatchConfig(configFile string, reloadSignal chan bool) error {
+	configDir := filepath.Dir(configFile)
 	if err := watcher.configWatcher.Add(configFile); err != nil {
 		return err
 	}
+
+	vcsPaths := []string{
+		filepath.Join(configDir, ".git", "HEAD"),
+		filepath.Join(configDir, ".hg", "branch"),
+	}
+
+	for _, path := range vcsPaths {
+		if err := watcher.configWatcher.Add(path); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	}
+
 	watcher.reloadSignal = reloadSignal
 	return nil
 }


### PR DESCRIPTION
fixes #361 

I have finally bit the bullet and added minimal vcs integration to help developers when they change branches. I have only supported git and mercurial since they have more common branch like usage. We may be able to add more in the future. This for now only works if the config file is in the root of the repo since the repo watching is relative to the config file.