### PR TITLE
Fixing query params encode so that it wont break with weird file names

### DIFF
--- a/kit/http_client.go
+++ b/kit/http_client.go
@@ -84,14 +84,14 @@ func (client *httpClient) ThemePath(themeID int64) string {
 }
 
 func (client *httpClient) AssetQuery(event EventType, query map[string]string) (*ShopifyResponse, Error) {
-	querystr := []string{}
-	for key, value := range query {
-		querystr = append(querystr, key+"="+value)
+	queryParams := url.Values{}
+	for key, val := range query {
+		queryParams.Set(key, val)
 	}
 	path := client.AssetPath()
 	rtype := listRequest
-	if len(querystr) > 0 {
-		path += "?" + strings.Join(querystr, "&")
+	if len(queryParams.Encode()) > 0 {
+		path += "?" + queryParams.Encode()
 		rtype = assetRequest
 	}
 	return client.sendRequest(rtype, event, path, nil)

--- a/kit/http_client_test.go
+++ b/kit/http_client_test.go
@@ -90,7 +90,7 @@ func (suite *HTTPClientTestSuite) TestAssetQuery() {
 
 	server = suite.NewTestServer(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(suite.T(), "GET", r.Method)
-		assert.Equal(suite.T(), "asset[key]=file.txt", r.URL.RawQuery)
+		assert.Equal(suite.T(), "asset%5Bkey%5D=file.txt", r.URL.RawQuery)
 		fmt.Fprintf(w, jsonFixture("responses/asset"))
 	})
 	resp, err = suite.client.AssetQuery(Retrieve, map[string]string{"asset[key]": "file.txt"})

--- a/kit/theme_client_test.go
+++ b/kit/theme_client_test.go
@@ -78,7 +78,7 @@ func (suite *ThemeClientTestSuite) TestAssetList() {
 func (suite *ThemeClientTestSuite) TestAsset() {
 	server := suite.NewTestServer(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(suite.T(), "GET", r.Method)
-		assert.Equal(suite.T(), "asset[key]=file.txt", r.URL.RawQuery)
+		assert.Equal(suite.T(), "asset%5Bkey%5D=file.txt", r.URL.RawQuery)
 		fmt.Fprintf(w, jsonFixture("responses/asset"))
 	})
 	defer server.Close()


### PR DESCRIPTION
There was a problem query params when there were spaces in the file names. This now encodes the params properly.