### PR TITLE
Disable verbose flag on open

### DIFF
--- a/cmd/open.go
+++ b/cmd/open.go
@@ -34,10 +34,7 @@ func preview(client kit.ThemeClient, filenames []string, wg *sync.WaitGroup) {
 }
 
 func openURL(env, url string) {
-	if verbose {
-		kit.Printf("[%s] opening %s", kit.GreenText(env), kit.GreenText(url))
-	}
-
+	kit.Printf("[%s] opening %s", kit.GreenText(env), kit.GreenText(url))
 	err := open.Run(url)
 	if err != nil {
 		kit.LogErrorf("[%s] %s", kit.GreenText(env), kit.RedText(err))


### PR DESCRIPTION
fixes #381 

Since the documented behaviour specifies that it prints out the url that is being opened, the message is no longer suppressed with the verbose flag.