### PR TITLE
Handling renaming events better

### DIFF
--- a/kit/file_watcher.go
+++ b/kit/file_watcher.go
@@ -203,7 +203,7 @@ func (watcher *FileWatcher) handleEvent(event fsnotify.Event) {
 		return
 	}
 	eventType := Update
-	if event.Op&fsnotify.Remove == fsnotify.Remove {
+	if event.Op&fsnotify.Remove == fsnotify.Remove || event.Op&fsnotify.Rename == fsnotify.Rename {
 		eventType = Remove
 	}
 	asset, _ := loadAsset(filepath.Dir(event.Name), filepath.Base(event.Name))


### PR DESCRIPTION
fixes https://github.com/Shopify/themekit/issues/392

**Problem**
In Atom and Sublime Text when deleting a file instead of a delete event, a rename happens. The editors rename the file to be in the trash can. Also while testing this it seems that the same would happen when renaming a file. The renamed file would have no content with the original filename and stay existing with the newly named file

**Solution**
*Change rename events to delete files.*
This solves renaming because it will delete the first file then create a new file with the new name and content.

**Problems**
This may cause confusion if a new developer tried deleting or renaming critical files because it will fire a delete action on the critical file and fail. Then it will succeed in creating the new file. Unfortunately I cannot see a way around this.

This has been validated for:

- [x] renaming
- [x] deleting in sublime
- [x] deleting in atom

cc @NathanPJF