### PR TITLE
Fixing updating compiled assets

### DIFF
--- a/kit/theme_client.go
+++ b/kit/theme_client.go
@@ -177,10 +177,8 @@ func (t ThemeClient) Perform(asset Asset, event EventType) (*ShopifyResponse, Er
 
 func (t ThemeClient) afterHooks(resp *ShopifyResponse, err Error) (*ShopifyResponse, Error) {
 	if resp.Code == 422 && strings.Contains(err.Error(), "Cannot overwrite generated asset") {
-		resp, err = t.Perform(Asset{Key: resp.Asset.Key + ".liquid"}, Remove)
-		if err != nil {
-			return resp, err
-		}
+		// No need to check the error because if it fails then remove will be tried again.
+		t.Perform(Asset{Key: resp.Asset.Key + ".liquid"}, Remove)
 		resp, err = t.Perform(resp.Asset, Update)
 	}
 


### PR DESCRIPTION
fixes https://github.com/Shopify/themekit/issues/279

This will automatically DELETE the liquid file and then re-upload the non-liquid file. Currently it shows no warning and the only indication that any different happened is that it takes a fraction of a second longer to finish the update.

TODO

- [x] Tests
- [x] Should a message be output or just make the changes unseen

This and the other open PR (https://github.com/Shopify/themekit/pull/395) should really fix up any file confusions for renaming and compiled files.

cc @NathanPJF for slate