### PR TITLE
Restricting the path checking to be more strict about project paths only

### DIFF
--- a/cmd/bootstrap_test.go
+++ b/cmd/bootstrap_test.go
@@ -39,7 +39,7 @@ func (suite *BootstrapTestSuite) TestBootstrap() {
 	err := bootstrap()
 	assert.NotNil(suite.T(), err)
 
-	flagConfig.Directory = "../fixtures/bootstrap"
+	flagConfig.Directory = "../fixtures"
 	flagConfig.Password = "foo"
 	flagConfig.Domain = server.URL + "/domain"
 	setFlagConfig()

--- a/kit/asset.go
+++ b/kit/asset.go
@@ -131,8 +131,7 @@ func loadAssetsFromDirectory(root, dir string, ignore func(path string) bool) ([
 
 func loadAsset(root, filename string) (asset Asset, err error) {
 	path := filepath.ToSlash(filepath.Join(root, filename))
-	path = strings.Replace(path, "\\", "/", -1)
-	asset = Asset{Key: pathToProject(path)}
+	asset = Asset{Key: pathToProject(root, path)}
 	file, err := os.Open(path)
 	if err != nil {
 		return asset, fmt.Errorf("loadAsset: %s", err)

--- a/kit/asset_test.go
+++ b/kit/asset_test.go
@@ -114,7 +114,7 @@ func (s *LoadAssetSuite) TestLoadAssetsFromDirectoryWithSubdir() {
 }
 
 func (s *LoadAssetSuite) TestLoadAsset() {
-	asset, err := loadAsset(clean("../fixtures/project"), clean("assets/application.js"))
+	asset, err := loadAsset(clean("../fixtures/project"), "assets/application.js")
 	assert.Equal(s.T(), "assets/application.js", asset.Key)
 	assert.Equal(s.T(), true, asset.IsValid())
 	assert.Equal(s.T(), "//this is js\n", asset.Value)

--- a/kit/file_filter.go
+++ b/kit/file_filter.go
@@ -3,6 +3,7 @@ package kit
 import (
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
@@ -41,6 +42,11 @@ func newFileFilter(rootDir string, patterns []string, files []string) (fileFilte
 	}
 
 	patterns = append(patterns, filePatterns...)
+
+	rootDir, symlinkErr := filepath.EvalSymlinks(filepath.Clean(rootDir))
+	if symlinkErr != nil {
+		return fileFilter{}, symlinkErr
+	}
 
 	if !strings.HasSuffix(rootDir, "/") {
 		rootDir += "/"
@@ -102,7 +108,7 @@ func (e fileFilter) filterAssets(assets []Asset) []Asset {
 }
 
 func (e fileFilter) matchesFilter(filename string) bool {
-	if len(filename) == 0 || !pathInProject(filename) {
+	if len(filename) == 0 || !pathInProject(e.rootDir, filename) {
 		return true
 	}
 

--- a/kit/file_filter.go
+++ b/kit/file_filter.go
@@ -23,6 +23,7 @@ var defaultRegexes = []*regexp.Regexp{
 	regexp.MustCompile(`Thumbs\.db`),
 	regexp.MustCompile(`desktop\.ini`),
 	regexp.MustCompile(`config.yml`),
+	regexp.MustCompile(`node_modules`),
 }
 
 var defaultGlobs = []string{}

--- a/kit/file_filter_test.go
+++ b/kit/file_filter_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 var (
-	rootDir           = "./root/dir/"
 	ignoreFixturePath = "../fixtures/project/valid_patterns"
 )
 
@@ -19,25 +18,25 @@ type EventFilterTestSuite struct {
 
 func (suite *EventFilterTestSuite) TestNewEventFilter() {
 	// loads files
-	filter, err := newFileFilter(rootDir, []string{}, []string{ignoreFixturePath})
+	filter, err := newFileFilter(watchFixturePath, []string{}, []string{ignoreFixturePath})
 	if assert.Nil(suite.T(), err) {
 		assert.Equal(suite.T(), append(defaultRegexes, regexp.MustCompile(`\.(txt|gif|bat)$`)), filter.filters)
-		assert.Equal(suite.T(), []string{"./root/dir/*config/settings.json", "./root/dir/*.png"}, filter.globs)
+		assert.Equal(suite.T(), []string{watchFixturePath + "/*config/settings.json", watchFixturePath + "/*.png"}, filter.globs)
 	}
 
 	// loads files
-	_, err = newFileFilter(rootDir, []string{}, []string{"bad path"})
+	_, err = newFileFilter(watchFixturePath, []string{}, []string{"bad path"})
 	assert.NotNil(suite.T(), err)
 
-	filter, err = newFileFilter(rootDir, []string{"config/settings.json", "*.png", "/\\.(txt|gif|bat)$/"}, []string{})
+	filter, err = newFileFilter(watchFixturePath, []string{"config/settings.json", "*.png", "/\\.(txt|gif|bat)$/"}, []string{})
 	if assert.Nil(suite.T(), err) {
 		assert.Equal(suite.T(), append(defaultRegexes, regexp.MustCompile(`\.(txt|gif|bat)$`)), filter.filters)
-		assert.Equal(suite.T(), []string{"./root/dir/*config/settings.json", "./root/dir/*.png"}, filter.globs)
+		assert.Equal(suite.T(), []string{watchFixturePath + "/*config/settings.json", watchFixturePath + "/*.png"}, filter.globs)
 	}
 }
 
 func (suite *EventFilterTestSuite) TestFilterAssets() {
-	filter, err := newFileFilter(rootDir, []string{".json", "*.txt", "*.gif", "*.ini", "*.bat"}, []string{})
+	filter, err := newFileFilter(watchFixturePath, []string{".json", "*.txt", "*.gif", "*.ini", "*.bat"}, []string{})
 	if assert.Nil(suite.T(), err) {
 		inputAssets := []Asset{{Key: "templates/foo.json.liquid"}, {Key: "templates/foo.json"}, {Key: "templates/foo.txt"}, {Key: "test.bat"}, {Key: "templates/zubat"}}
 		expectedAssets := []Asset{{Key: "templates/foo.json.liquid"}, {Key: "templates/zubat"}}
@@ -58,37 +57,37 @@ func (suite *EventFilterTestSuite) TestMatchesFilter() {
 	}
 
 	// it filters plain filenames
-	filter, err := newFileFilter(rootDir, []string{"build/", "test.txt"}, []string{})
+	filter, err := newFileFilter(watchFixturePath, []string{"build/", "test.txt"}, []string{})
 	if assert.Nil(suite.T(), err) {
 		check(
 			filter,
-			[]string{rootDir + "/foo/test.txt", "test.txt", "templates/test.txt", "build/hello/world", "build/world", "templates/world", "config/zubat"},
+			[]string{watchFixturePath + "/foo/test.txt", "test.txt", "templates/test.txt", "build/hello/world", "build/world", "templates/world", "config/zubat"},
 			[]string{"templates/world", "config/zubat"},
 		)
 	}
 
 	// it filters globs
-	filter, err = newFileFilter(rootDir, []string{".json", "*.txt", "*.gif", "*.ini", "*.bat"}, []string{})
+	filter, err = newFileFilter(watchFixturePath, []string{".json", "*.txt", "*.gif", "*.ini", "*.bat"}, []string{})
 	if assert.Nil(suite.T(), err) {
 		check(
 			filter,
-			[]string{rootDir + "config/settings.json", "hello.bat", "build/hello/world.gif", "build/world.txt", "templates/whatever", "foo.ini", "templates/zubat"},
+			[]string{watchFixturePath + "/config/settings.json", "hello.bat", "build/hello/world.gif", "build/world.txt", "templates/whatever", "foo.ini", "templates/zubat"},
 			[]string{"templates/whatever", "templates/zubat"},
 		)
 	}
 
 	// filters proper regex
-	filter, err = newFileFilter(rootDir, []string{`/\.(txt|gif|bat|json|ini)$/`}, []string{})
+	filter, err = newFileFilter(watchFixturePath, []string{`/\.(txt|gif|bat|json|ini)$/`}, []string{})
 	if assert.Nil(suite.T(), err) {
 		check(
 			filter,
-			[]string{rootDir + "config/settings.json", "", "hello.bat", "build/hello/world.gif", "build/world.txt", "templates/whatever", "foo.ini", "templates/zubat"},
+			[]string{watchFixturePath + "/config/settings.json", "", "hello.bat", "build/hello/world.gif", "build/world.txt", "templates/whatever", "foo.ini", "templates/zubat"},
 			[]string{"templates/whatever", "templates/zubat"},
 		)
 	}
 
 	//check default filters
-	filter, err = newFileFilter(rootDir, []string{}, []string{})
+	filter, err = newFileFilter(watchFixturePath, []string{}, []string{})
 	if assert.Nil(suite.T(), err) {
 		check(
 			filter,
@@ -97,7 +96,7 @@ func (suite *EventFilterTestSuite) TestMatchesFilter() {
 		)
 	}
 
-	filter, err = newFileFilter(rootDir, []string{"config/settings_schema.json", "config/settings_data.json", "*.jpg", "*.png"}, []string{})
+	filter, err = newFileFilter(watchFixturePath, []string{"config/settings_schema.json", "config/settings_data.json", "*.jpg", "*.png"}, []string{})
 	if assert.Nil(suite.T(), err) {
 		assert.Equal(suite.T(), true, filter.matchesFilter(""))
 	}

--- a/kit/path.go
+++ b/kit/path.go
@@ -18,33 +18,37 @@ var (
 	}
 )
 
-func pathInProject(filename string) bool {
-	return pathToProject(filename) != "" || isProjectDirectory(filename)
+func pathInProject(root, filename string) bool {
+	return pathToProject(root, filename) != "" || isProjectDirectory(root, filename)
 }
 
-func isProjectDirectory(filename string) bool {
+func isProjectDirectory(root, filename string) bool {
+	filename = strings.TrimPrefix(
+		filepath.ToSlash(filepath.Clean(filename)),
+		filepath.Clean(root)+"/",
+	)
+
 	for _, dir := range assetLocations {
-		if directoriesEqual(filename, dir) {
+		if dir == filename {
 			return true
 		}
 	}
+
 	return false
 }
 
-func directoriesEqual(dir, other string) bool {
-	return strings.HasSuffix(
-		filepath.Clean(filepath.ToSlash(dir)+"/"),
-		filepath.Clean(filepath.ToSlash(other)+"/"),
+func pathToProject(root, filename string) string {
+	filename = strings.TrimPrefix(
+		filepath.ToSlash(filepath.Clean(filename)),
+		filepath.Clean(root)+"/",
 	)
-}
 
-func pathToProject(filename string) string {
-	filename = filepath.ToSlash(filepath.Clean(filename))
 	for _, dir := range assetLocations {
 		split := strings.SplitAfterN(filename, dir+"/", 2)
-		if len(split) > 1 {
+		if len(split) > 1 && strings.HasPrefix(filename, dir+"/") {
 			return filepath.ToSlash(filepath.Join(dir, split[len(split)-1]))
 		}
 	}
+
 	return ""
 }

--- a/kit/path_test.go
+++ b/kit/path_test.go
@@ -13,56 +13,61 @@ type PathTestSuite struct {
 }
 
 func (suite *PathTestSuite) TestPathToProject() {
+	root := filepath.Join("long", "path", "to")
 	tests := map[string]string{
-		filepath.Join("long", "path", "to", "config.yml"):                            "",
-		filepath.Join("long", "path", "to", "assets", "logo.png"):                    "assets/logo.png",
-		filepath.Join("long", "path", "to", "templates", "customers", "test.liquid"): "templates/customers/test.liquid",
-		filepath.Join("long", "path", "to", "config", "test.liquid"):                 "config/test.liquid",
-		filepath.Join("long", "path", "to", "layout", "test.liquid"):                 "layout/test.liquid",
-		filepath.Join("long", "path", "to", "snippets", "test.liquid"):               "snippets/test.liquid",
-		filepath.Join("long", "path", "to", "templates", "test.liquid"):              "templates/test.liquid",
-		filepath.Join("long", "path", "to", "locales", "test.liquid"):                "locales/test.liquid",
-		filepath.Join("long", "path", "to", "sections", "test.liquid"):               "sections/test.liquid",
+		filepath.Join(root, "config.yml"):                            "",
+		filepath.Join(root, "assets", "logo.png"):                    "assets/logo.png",
+		filepath.Join(root, "node_modules", "assets", "logo.png"):    "",
+		filepath.Join(root, "templates", "customers", "test.liquid"): "templates/customers/test.liquid",
+		filepath.Join(root, "config", "test.liquid"):                 "config/test.liquid",
+		filepath.Join(root, "layout", "test.liquid"):                 "layout/test.liquid",
+		filepath.Join(root, "snippets", "test.liquid"):               "snippets/test.liquid",
+		filepath.Join(root, "templates", "test.liquid"):              "templates/test.liquid",
+		filepath.Join(root, "locales", "test.liquid"):                "locales/test.liquid",
+		filepath.Join(root, "sections", "test.liquid"):               "sections/test.liquid",
 	}
 	for input, expected := range tests {
-		assert.Equal(suite.T(), expected, pathToProject(input))
+		assert.Equal(suite.T(), expected, pathToProject(root, input))
 	}
 }
 
 func (suite *PathTestSuite) TestDirInProject() {
+	root := filepath.Join("long", "path", "to")
 	tests := map[string]bool{
 		"": false,
-		filepath.Join("long", "path", "to", "misc"):                false,
-		filepath.Join("long", "path", "to", "assets"):              true,
-		filepath.Join("long", "path", "to", "templates/customers"): true,
-		filepath.Join("long", "path", "to", "config"):              true,
-		filepath.Join("long", "path", "to", "layout"):              true,
-		filepath.Join("long", "path", "to", "snippets"):            true,
-		filepath.Join("long", "path", "to", "templates"):           true,
-		filepath.Join("long", "path", "to", "locales"):             true,
-		filepath.Join("long", "path", "to", "sections"):            true,
+		filepath.Join(root, "misc"):                false,
+		filepath.Join(root, "assets"):              true,
+		filepath.Join(root, "templates/customers"): true,
+		filepath.Join(root, "config"):              true,
+		filepath.Join(root, "layout"):              true,
+		filepath.Join(root, "snippets"):            true,
+		filepath.Join(root, "templates"):           true,
+		filepath.Join(root, "locales"):             true,
+		filepath.Join(root, "sections"):            true,
 	}
 	for input, expected := range tests {
-		assert.Equal(suite.T(), expected, isProjectDirectory(input), input)
+		assert.Equal(suite.T(), expected, isProjectDirectory(root, input), input)
 	}
 }
 
 func (suite *PathTestSuite) TestPathInProject() {
+	root := filepath.Join("long", "path", "to")
 	tests := map[string]bool{
 		"": false,
-		filepath.Join("long", "path", "to", "config.yml"):                            false,
-		filepath.Join("long", "path", "to", "misc", "other.html"):                    false,
-		filepath.Join("long", "path", "to", "assets", "logo.png"):                    true,
-		filepath.Join("long", "path", "to", "templates", "customers", "test.liquid"): true,
-		filepath.Join("long", "path", "to", "config", "test.liquid"):                 true,
-		filepath.Join("long", "path", "to", "layout", "test.liquid"):                 true,
-		filepath.Join("long", "path", "to", "snippets", "test.liquid"):               true,
-		filepath.Join("long", "path", "to", "templates", "test.liquid"):              true,
-		filepath.Join("long", "path", "to", "locales", "test.liquid"):                true,
-		filepath.Join("long", "path", "to", "sections", "test.liquid"):               true,
+		filepath.Join(root, "config.yml"):                            false,
+		filepath.Join(root, "misc", "other.html"):                    false,
+		filepath.Join(root, "assets", "logo.png"):                    true,
+		filepath.Join(root, "node_modules", "assets", "logo.png"):    false,
+		filepath.Join(root, "templates", "customers", "test.liquid"): true,
+		filepath.Join(root, "config", "test.liquid"):                 true,
+		filepath.Join(root, "layout", "test.liquid"):                 true,
+		filepath.Join(root, "snippets", "test.liquid"):               true,
+		filepath.Join(root, "templates", "test.liquid"):              true,
+		filepath.Join(root, "locales", "test.liquid"):                true,
+		filepath.Join(root, "sections", "test.liquid"):               true,
 	}
 	for input, expected := range tests {
-		assert.Equal(suite.T(), expected, pathInProject(input), input)
+		assert.Equal(suite.T(), expected, pathInProject(root, input), input)
 	}
 }
 

--- a/kit/theme_client.go
+++ b/kit/theme_client.go
@@ -41,7 +41,7 @@ func NewThemeClient(config *Configuration) (ThemeClient, error) {
 
 // NewFileWatcher creates a new filewatcher using the theme clients file filter
 func (t ThemeClient) NewFileWatcher(notifyFile string, callback FileEventCallback) (*FileWatcher, error) {
-	return newFileWatcher(t, t.Config.Directory, notifyFile, true, t.filter, callback)
+	return newFileWatcher(t, notifyFile, true, t.filter, callback)
 }
 
 // AssetList will return a slice of remote assets from the shopify servers. The


### PR DESCRIPTION
fixes https://github.com/Shopify/themekit/issues/388

It was noticed that some paths would match up with paths in the node_modules folder causing weird errors while uploading. This exposed the fact that path matching was too fuzy and probably eating up extra cpu just checking large node modules structures. 

This PR restricts all path matching, any function that makes sure a file is valid for upload is restricted to the root directory as specified by the users configuration. It was also exposed that file filtering probably didn't work through symlinks either so that was fixed in this PR as well.

This is still WIP because it is quite a substantial change and could have some potential for bugs so I will need to test it thoroughly. The tests were not changed much and they all pass however I would like to do trial runs by hand.