### PR TITLE
Added the ability to glob env flag and have multiple env flags

### DIFF
--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -31,6 +31,6 @@ func saveConfiguration(config *kit.Configuration) error {
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
-	env.SetConfiguration(environment, config)
+	env.SetConfiguration(kit.DefaultEnvironment, config)
 	return env.Save(configPath)
 }

--- a/cmd/configure_test.go
+++ b/cmd/configure_test.go
@@ -10,10 +10,9 @@ import (
 )
 
 func TestSaveConfiguration(t *testing.T) {
-	environment = "default"
 	configPath = goodEnvirontmentPath
 	env, err := kit.LoadEnvironments(configPath)
-	config, _ := env.GetConfiguration(environment)
+	config, _ := env.GetConfiguration(kit.DefaultEnvironment)
 
 	err = saveConfiguration(config)
 	assert.Nil(t, err)

--- a/cmd/theme_test.go
+++ b/cmd/theme_test.go
@@ -26,10 +26,10 @@ func (suite *ThemeTestSuite) TestGenerateThemeClients() {
 	assert.Nil(suite.T(), err)
 	assert.Equal(suite.T(), 1, len(clients))
 
-	environment = "nope"
+	environments = stringArgArray{[]string{"nope"}}
 	clients, err = generateThemeClients()
 	assert.NotNil(suite.T(), err)
-	environment = "development"
+	environments = stringArgArray{[]string{"development"}}
 
 	allenvs = true
 	clients, err = generateThemeClients()
@@ -40,6 +40,28 @@ func (suite *ThemeTestSuite) TestGenerateThemeClients() {
 	configPath = badEnvirontmentPath
 	_, err = generateThemeClients()
 	assert.NotNil(suite.T(), err)
+}
+
+func (suite *ThemeTestSuite) TestUseEnvironment() {
+	environments = stringArgArray{}
+	assert.True(suite.T(), useEnvironment("development"))
+
+	environments = stringArgArray{[]string{"production"}}
+	assert.True(suite.T(), useEnvironment("production"))
+
+	allenvs = true
+	environments = stringArgArray{}
+	assert.True(suite.T(), useEnvironment("nope"))
+	allenvs = false
+
+	environments = stringArgArray{[]string{"p*"}}
+	assert.True(suite.T(), useEnvironment("production"))
+	assert.True(suite.T(), useEnvironment("prod"))
+	assert.True(suite.T(), useEnvironment("puddle"))
+	assert.False(suite.T(), useEnvironment("development"))
+
+	environments = stringArgArray{}
+	assert.False(suite.T(), useEnvironment("production"))
 }
 
 func (suite *ThemeTestSuite) TestForEachClient() {


### PR DESCRIPTION
### WHAT are you trying to accomplish with this PR?
fixes #417 
- Added wildcards to environment variables however depending on your shell you will probably need quotation marks around any wildcards like: `theme --env="client-*" uplodate`
- Added the ability to use multiple env flags like: `theme --env=production --env=development upload`

### WHY are you choosing this approach?
To implement having several *selected* environments/clients loaded at one time I had to implement having the ability to load independent environments. This added the ability for multiple env flags which I think is a good feature to have as well.

### HOW is this accomplished?
Changed how environments/theme clients are loaded to have a environment name matcher. 

### Anything that could go wrong?
Tests have been added for all situation for loading environment. This seems low risk

### Checklist

- [x] It is safe to simply rollback this change.
- [x] I have :tophat:'d these changes by using the commands I changed by hand
