### PR TITLE
Flags and Envs only take effect on active environments.

### DIFF
--- a/cmd/bootstrap_test.go
+++ b/cmd/bootstrap_test.go
@@ -126,11 +126,11 @@ func TestSaveConfiguration(t *testing.T) {
 
 	kittest.GenerateConfig("example.myshopify.io", true)
 	env, _ := kit.LoadEnvironments("config.yml")
-	config, _ := env.GetConfiguration(kit.DefaultEnvironment)
+	config, _ := env.GetConfiguration(kit.DefaultEnvironment, true)
 	assert.Nil(t, saveConfiguration(config))
 
 	kittest.GenerateConfig("example.myshopify.io", false)
 	env, _ = kit.LoadEnvironments("config.yml")
-	config, _ = env.GetConfiguration(kit.DefaultEnvironment)
+	config, _ = env.GetConfiguration(kit.DefaultEnvironment, true)
 	assert.NotNil(t, saveConfiguration(config))
 }

--- a/cmd/command_arbiter.go
+++ b/cmd/command_arbiter.go
@@ -66,7 +66,8 @@ func (arbiter *commandArbiter) generateThemeClients(cmd *cobra.Command, args []s
 	}
 
 	for env := range configEnvs {
-		config, err := configEnvs.GetConfiguration(env)
+		isActive := arbiter.shouldUseEnvironment(env)
+		config, err := configEnvs.GetConfiguration(env, isActive)
 		if err != nil {
 			return fmt.Errorf(
 				`[%s] %s All environments are required to be valid so that asset versions can be validated`,
@@ -91,7 +92,7 @@ func (arbiter *commandArbiter) generateThemeClients(cmd *cobra.Command, args []s
 			return err
 		}
 
-		if arbiter.shouldUseEnvironment(env) {
+		if isActive {
 			arbiter.activeThemeClients = append(arbiter.activeThemeClients, client)
 		}
 		arbiter.allThemeClients = append(arbiter.allThemeClients, client)

--- a/kit/configuration.go
+++ b/kit/configuration.go
@@ -58,13 +58,15 @@ func SetFlagConfig(config Configuration) {
 // formatted configuration along with any validation errors. The config precedence
 // is flags, environment variables, then the config file.
 func NewConfiguration() (*Configuration, error) {
-	return (&Configuration{}).compile()
+	return (&Configuration{}).compile(true)
 }
 
-func (conf *Configuration) compile() (*Configuration, error) {
+func (conf *Configuration) compile(active bool) (*Configuration, error) {
 	newConfig := &Configuration{}
-	mergo.Merge(newConfig, &flagConfig)
-	mergo.Merge(newConfig, &environmentConfig)
+	if active {
+		mergo.Merge(newConfig, &flagConfig)
+		mergo.Merge(newConfig, &environmentConfig)
+	}
 	mergo.Merge(newConfig, conf)
 	mergo.Merge(newConfig, &defaultConfig)
 	return newConfig, newConfig.Validate()

--- a/kit/configuration_test.go
+++ b/kit/configuration_test.go
@@ -55,16 +55,20 @@ func TestConfiguration_Precedence(t *testing.T) {
 	defer resetConfig()
 
 	config := &Configuration{Password: "file"}
-	config, _ = config.compile()
+	config, _ = config.compile(true)
 	assert.Equal(t, "file", config.Password)
 
 	environmentConfig = Configuration{Password: "environment"}
-	config, _ = config.compile()
+	config, _ = config.compile(true)
 	assert.Equal(t, "environment", config.Password)
 
 	flagConfig = Configuration{Password: "flag"}
-	config, _ = config.compile()
+	config, _ = config.compile(true)
 	assert.Equal(t, "flag", config.Password)
+
+	config = &Configuration{Password: "file"}
+	config, _ = config.compile(false)
+	assert.Equal(t, "file", config.Password)
 }
 
 func TestConfiguration_Validate(t *testing.T) {

--- a/kit/environments.go
+++ b/kit/environments.go
@@ -62,8 +62,11 @@ func (e Environments) SetConfiguration(environmentName string, conf *Configurati
 }
 
 // GetConfiguration will return the configuration for the environment. An error will
-// be returned if the environment does not exist or the configuration is invalid.
-func (e Environments) GetConfiguration(environmentName string) (*Configuration, error) {
+// be returned if the environment does not exist or the configuration is invalid. The
+// active parameter indicates if the configuration should take configuration values from
+// environment and flags. This is considered active because passive configurations only
+// take configuration from the config file and defaults.
+func (e Environments) GetConfiguration(environmentName string, active bool) (*Configuration, error) {
 	conf, exists := e[environmentName]
 	if !exists {
 		return conf, fmt.Errorf("%s does not exist in this environments list", environmentName)
@@ -75,7 +78,7 @@ Please see %s for examples`,
 			blue("http://shopify.github.io/themekit/configuration/#config-file"))
 	}
 	conf.Environment = environmentName
-	return conf.compile()
+	return conf.compile(active)
 }
 
 // Save will write out the environment to a file.

--- a/kit/environments_test.go
+++ b/kit/environments_test.go
@@ -64,12 +64,12 @@ func TestEnvironments_GetConfiguration(t *testing.T) {
 	kittest.GenerateConfig("example.myshopify.io", true)
 	envs, err := LoadEnvironments("config.yml")
 	assert.Nil(t, err)
-	_, err = envs.GetConfiguration("development")
+	_, err = envs.GetConfiguration("development", true)
 	assert.Nil(t, err)
-	_, err = envs.GetConfiguration("nope")
+	_, err = envs.GetConfiguration("nope", true)
 	assert.NotNil(t, err)
 	envs["test"] = nil
-	_, err = envs.GetConfiguration("test")
+	_, err = envs.GetConfiguration("test", true)
 	assert.NotNil(t, err)
 }
 


### PR DESCRIPTION
In the newest version since all environments are loaded simultaneously to check asset versions there is some problems about which environments that flags and environment variables take effect. I thought about this for a long time and decided that it is much more intuitive to only apply them to the active environments. This means that they are applied to the environments that the developer expects to be working on and not any of the other environments. This PR makes it so that these configurations are only merged in when the environment is active.