### PR TITLE
Added backfilling for versions not yet recorded when manifest is built

### DIFF
--- a/cmd/command_arbiter_test.go
+++ b/cmd/command_arbiter_test.go
@@ -45,6 +45,8 @@ func TestCommandArbiter_GenerateManifest(t *testing.T) {
 func TestCommandArbiter_GenerateThemeClients(t *testing.T) {
 	server := kittest.NewTestServer()
 	defer server.Close()
+	defer kittest.Cleanup()
+	defer resetArbiter()
 
 	err := arbiter.generateThemeClients(nil, []string{})
 	assert.NotNil(t, err)
@@ -56,9 +58,12 @@ func TestCommandArbiter_GenerateThemeClients(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.True(t, strings.Contains(err.Error(), "Invalid yaml found"))
 
+	assert.Nil(t, kittest.GenerateBadMultiConfig(server.URL))
+	err = arbiter.generateThemeClients(nil, []string{})
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "environments are required to be valid"))
+
 	assert.Nil(t, kittest.GenerateConfig(server.URL, true))
-	defer kittest.Cleanup()
-	defer resetArbiter()
 
 	arbiter.environments = stringArgArray{[]string{"nope"}}
 	err = arbiter.generateThemeClients(nil, []string{})
@@ -76,7 +81,7 @@ func TestCommandArbiter_GenerateThemeClients(t *testing.T) {
 	assert.Nil(t, arbiter.generateThemeClients(nil, []string{}))
 
 	kittest.Cleanup()
-	assert.Nil(t, kittest.GenerateProxyConfig(server.URL, false))
+	assert.Nil(t, kittest.GenerateProxyConfig(server.URL))
 	arbiter.generateThemeClients(nil, []string{})
 	assert.True(t, strings.Contains(stdOutOutput.String(), "Proxy URL detected from Configuration"))
 }


### PR DESCRIPTION
While testing I noticed that if I

- downloaded a theme
- added a new environment to my config.yml
- ran `theme download` again

All files would be skipped because they had not been updated and so the new environment versions were not added to the `theme.lock`. This PR adds in functionality that will add missing versions to the theme.lock when the manifest if built. This means upon running any command, themekit will check each client, and add any missing versions to the manifest.