### PR TITLE
Added a browser flag for opening editor in different editor

### DIFF
--- a/cmd/open.go
+++ b/cmd/open.go
@@ -9,7 +9,12 @@ import (
 	"github.com/Shopify/themekit/kit"
 )
 
-var openFunc = open.Run
+var openFunc = func(url string) error {
+	if openWith == "" {
+		return open.Run(url)
+	}
+	return open.RunWith(url, openWith)
+}
 
 var openCmd = &cobra.Command{
 	Use:   "open",

--- a/cmd/theme.go
+++ b/cmd/theme.go
@@ -18,6 +18,7 @@ var (
 	bootstrapName    string
 	setThemeID       bool
 	openEdit         bool
+	openWith         string
 	updateVersion    string
 	noUpdateNotifier bool
 
@@ -94,6 +95,7 @@ func init() {
 	updateCmd.Flags().StringVar(&updateVersion, "version", "latest", "version of themekit to install")
 
 	openCmd.Flags().BoolVarP(&openEdit, "edit", "E", false, "open the web editor for the theme.")
+	openCmd.Flags().StringVarP(&openWith, "browser", "b", "", "name of the browser to open the url. the name should match the name of browser on your system.")
 
 	ThemeCmd.AddCommand(
 		bootstrapCmd,


### PR DESCRIPTION
fixes #427 

This will enable the user to open the preview in a target browser by name. This name is defined by the OS so I cannot make simplified options like `--canary` This means that 

- `theme open -b=firefox`
- `theme open --browser="google chrome"`
- `theme open -b="google chrome canary"`

Will all work if those browsers are installed on the system however `theme open -b=canary` will not work. I currently have no way of querying which browsers exist so I cannot create the simplified options or allow fuzzy matching of browser names.