### PR TITLE
Download was not ignoring files properly on download

### DIFF
--- a/cmd/file_manifest.go
+++ b/cmd/file_manifest.go
@@ -179,8 +179,10 @@ func (manifest *fileManifest) Should(event kit.EventType, filename, environment 
 func (manifest *fileManifest) FetchableFiles(filenames []string, env string) []string {
 	fetchableFilenames := []string{}
 	if len(filenames) <= 0 {
-		for assetName := range manifest.remote {
-			fetchableFilenames = append(fetchableFilenames, assetName)
+		for assetName, envs := range manifest.remote {
+			if _, ok := envs[env]; ok {
+				fetchableFilenames = append(fetchableFilenames, assetName)
+			}
 		}
 	} else {
 		wildCards := []string{}

--- a/cmd/file_manifest_test.go
+++ b/cmd/file_manifest_test.go
@@ -166,10 +166,14 @@ func TestFileManifest_FetchableFiles(t *testing.T) {
 		remote: map[string]map[string]string{
 			"assets/goodbye.txt": {env: now},
 			"assets/hello.txt":   {env: now},
+			"assets/no.txt":      {"other": now},
 		},
 	}
 
-	filenames := manifest.FetchableFiles([]string{"assets/hello.txt"}, env)
+	filenames := manifest.FetchableFiles([]string{}, env)
+	assert.Equal(t, len(filenames), 2)
+
+	filenames = manifest.FetchableFiles([]string{"assets/hello.txt"}, env)
 	assert.Equal(t, len(filenames), 1)
 
 	filenames = manifest.FetchableFiles([]string{"assets/goodbye*", "templates/404.html"}, env)


### PR DESCRIPTION
Since fetchable files were generated from the manifest and remote files are coming from all sources, if another environment didn't ignore the file then it would still exist in the remote manifest. This will check that the file is in the current environment before adding it to the fetchable list.
