### PR TITLE
Saftey check for progress bar

### DIFF
--- a/cmd/command_arbiter.go
+++ b/cmd/command_arbiter.go
@@ -151,7 +151,7 @@ func (arbiter *commandArbiter) setFlagConfig() {
 
 func (arbiter *commandArbiter) newProgressBar(count int, name string) *mpb.Bar {
 	var bar *mpb.Bar
-	if !arbiter.verbose {
+	if !arbiter.verbose && count > 0 {
 		bar = arbiter.progress.AddBar(int64(count)).
 			PrependName(fmt.Sprintf("[%s]: ", name), 0).
 			AppendPercentage().


### PR DESCRIPTION
rel #436 

This PR doesn't narrow down the reason it happens but it will prevent themekit from ever hanging like this. If the count is equal to 0 it will not start a progress bar.
