### PR TITLE
Prune now only prunes files not on disk

### DIFF
--- a/cmd/file_manifest.go
+++ b/cmd/file_manifest.go
@@ -102,16 +102,16 @@ func (manifest *fileManifest) backfillLocal() (err error) {
 }
 
 func (manifest *fileManifest) prune(clients []kit.ThemeClient) error {
-	// prune files that no longer exist
+	// prune files that are no longer on disk
 	for filename := range manifest.local {
-		if _, found := manifest.remote[filename]; !found {
-			if i := indexOf(len(clients), func(i int) bool {
-				info, err := os.Stat(filepath.ToSlash(filepath.Join(clients[i].Config.Directory, filename)))
-				return err == nil && !info.IsDir()
-			}); i == -1 {
-				if err := manifest.store.DeleteCollection(filename); err != nil {
-					return err
-				}
+		onDisk := indexOf(len(clients), func(i int) bool {
+			info, err := os.Stat(filepath.ToSlash(filepath.Join(clients[i].Config.Directory, filename)))
+			return err == nil && !info.IsDir()
+		}) != -1
+
+		if !onDisk {
+			if err := manifest.store.DeleteCollection(filename); err != nil {
+				return err
 			}
 		}
 	}


### PR DESCRIPTION
While doing QA I realized that once a file is in the manifest and the timestamp is updated, the file will no longer be downloaded if the file is deleted. 

Previously while pruning files from the manifest I would only prune a file if it didn't exist on remote as well as on disk however I have changed it to prune files that only don't exist on the disk. This is better because it doesn't matter if the file is still on the remote. The user cannot update/overwrite file changes if the file does not exist. Now that the file will be pruned from the manifest if it didn't exist, this means it will be downloaded when download is called since it no longer exists in the manifest.