### PR TITLE
Remove was not removing files with the same date

### DIFF
--- a/cmd/file_manifest.go
+++ b/cmd/file_manifest.go
@@ -164,7 +164,7 @@ func (manifest *fileManifest) ShouldUpload(asset kit.Asset, environment string) 
 
 func (manifest *fileManifest) ShouldRemove(filename, environment string) bool {
 	localTime, remoteTime := manifest.diffDates(filename, environment, environment)
-	return remoteTime.Before(localTime) || localTime.IsZero()
+	return remoteTime.Before(localTime) || remoteTime.Equal(localTime) || localTime.IsZero()
 }
 
 func (manifest *fileManifest) Should(event kit.EventType, asset kit.Asset, environment string) bool {

--- a/cmd/file_manifest_test.go
+++ b/cmd/file_manifest_test.go
@@ -136,7 +136,7 @@ func TestFileManifest_Should(t *testing.T) {
 	}
 
 	assert.False(t, manifest.Should(kit.Update, asset, env))
-	assert.False(t, manifest.Should(kit.Remove, asset, env))
+	assert.True(t, manifest.Should(kit.Remove, asset, env))
 	assert.False(t, manifest.Should(kit.Retrieve, asset, env))
 
 	manifest.local[asset.Key][env] = now

--- a/cmd/remove_test.go
+++ b/cmd/remove_test.go
@@ -27,7 +27,11 @@ func TestRemove(t *testing.T) {
 			assert.Equal(t, "DELETE", server.Requests[0].Method)
 		}
 
-		arbiter.manifest.Set("templates/layout.liquid", "development", "2011-07-06T02:04:21-11:00", "123sum456")
+		asset, env, then, now := "templates/layout.liquid", "development", "2011-07-06T02:04:21-11:00", "2012-07-06T02:04:21-11:00"
+		arbiter.manifest = &fileManifest{
+			local:  map[string]map[string]string{asset: {env: then}},
+			remote: map[string]map[string]string{asset: {env: now}},
+		}
 		arbiter.force = false
 		err = remove(client, []string{"templates/layout.liquid"})
 		assert.True(t, strings.Contains(err.Error(), "file was modified remotely"))


### PR DESCRIPTION
When running the remove command, it would not remove a file that was not updated but because it was checking that the remote time was Before local and if they were equal it would assume that the file had been modified.
