### PR TITLE
Fixing env flag on config command

### DIFF
--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -156,6 +156,15 @@ func saveConfiguration(config *kit.Configuration) error {
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
-	env.SetConfiguration(kit.DefaultEnvironment, config)
+
+	flagEnvs := arbiter.environments.Value()
+	if len(flagEnvs) == 0 {
+		env.SetConfiguration(kit.DefaultEnvironment, config)
+	} else {
+		for _, envName := range flagEnvs {
+			env.SetConfiguration(envName, config)
+		}
+	}
+
 	return env.Save(arbiter.configPath)
 }


### PR DESCRIPTION
fixes #444 

When I refactored everything I made the incorrect assumption that the config command was only used for the development environment. This adds back in the `env` flag behaviour.