### PR TITLE
Skipping invalid environments in the manifest, allowing reusable config

### DIFF
--- a/cmd/command_arbiter.go
+++ b/cmd/command_arbiter.go
@@ -69,11 +69,7 @@ func (arbiter *commandArbiter) generateThemeClients(cmd *cobra.Command, args []s
 		isActive := arbiter.shouldUseEnvironment(env)
 		config, err := configEnvs.GetConfiguration(env, isActive)
 		if err != nil {
-			return fmt.Errorf(
-				`[%s] %s All environments are required to be valid so that asset versions can be validated`,
-				green(config.Environment),
-				yellow(err.Error()),
-			)
+			continue
 		}
 		if arbiter.disableIgnore {
 			config.IgnoredFiles = []string{}

--- a/cmd/command_arbiter_test.go
+++ b/cmd/command_arbiter_test.go
@@ -58,11 +58,6 @@ func TestCommandArbiter_GenerateThemeClients(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.True(t, strings.Contains(err.Error(), "Invalid yaml found"))
 
-	assert.Nil(t, kittest.GenerateBadMultiConfig(server.URL))
-	err = arbiter.generateThemeClients(nil, []string{})
-	assert.NotNil(t, err)
-	assert.True(t, strings.Contains(err.Error(), "environments are required to be valid"))
-
 	assert.Nil(t, kittest.GenerateConfig(server.URL, true))
 
 	arbiter.environments = stringArgArray{[]string{"nope"}}


### PR DESCRIPTION
fixes #446

Currently themekit checks all environments strictly for version checking however this does not allow for reusable config like this:

```
production: # LIVE WEBSITE
  theme_id: ********
  readonly: true # safety switch; toggle to deploy
  << : *common
config: &common
  password: *********************
  store: storename.myshopify.com
  ignore_files:
    - src/
    - node_modules/
    - Gulpfile.js
    - package.json
```

Because the `config` environment would be invalid. I don't love this because if some of the environments are invalid I won't be able to backfill the manifest with versions. However when upload/replacing on different environments, the backfills aren't *really* necessary. I was just being greedy with that information.