### PR TITLE
Added symlink eval to config validation

### DIFF
--- a/cmd/command_arbiter_test.go
+++ b/cmd/command_arbiter_test.go
@@ -154,7 +154,7 @@ func TestCommandArbiter_SetFlagConfig(t *testing.T) {
 	defer resetArbiter()
 	arbiter.flagConfig.Password = "foo"
 	arbiter.flagConfig.Domain = "bar.myshopify.com"
-	arbiter.flagConfig.Directory = "my/dir/now"
+	arbiter.flagConfig.Directory = "../kit"
 	arbiter.flagConfig.ThemeID = "123"
 	arbiter.setFlagConfig()
 
@@ -162,7 +162,7 @@ func TestCommandArbiter_SetFlagConfig(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "foo", config.Password)
 	assert.Equal(t, "bar.myshopify.com", config.Domain)
-	assert.Equal(t, "my/dir/now", config.Directory)
+	assert.Equal(t, "../kit", config.Directory)
 	assert.Equal(t, "123", config.ThemeID)
 }
 

--- a/cmd/watch_test.go
+++ b/cmd/watch_test.go
@@ -55,7 +55,7 @@ func TestWatch(t *testing.T) {
 
 		kittest.Cleanup()
 		err = watch()
-		assert.Equal(t, err.Error(), "lstat fixtures: no such file or directory")
+		assert.Equal(t, err.Error(), "lstat fixtures/project: no such file or directory")
 	}
 }
 

--- a/kit/configuration.go
+++ b/kit/configuration.go
@@ -3,6 +3,7 @@ package kit
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -74,7 +75,7 @@ func (conf *Configuration) compile(active bool) (*Configuration, error) {
 
 // Validate will check the configuration for any problems that will cause theme kit
 // to function incorrectly.
-func (conf Configuration) Validate() error {
+func (conf *Configuration) Validate() error {
 	errors := []string{}
 
 	if conf.ThemeID == "" {
@@ -92,10 +93,11 @@ func (conf Configuration) Validate() error {
 	if len(errors) > 0 {
 		return fmt.Errorf("Invalid configuration: %v", strings.Join(errors, ","))
 	}
+
 	return nil
 }
 
-func (conf Configuration) validateNoThemeID() error {
+func (conf *Configuration) validateNoThemeID() error {
 	errors := []string{}
 
 	if len(conf.Domain) == 0 {
@@ -108,6 +110,12 @@ func (conf Configuration) validateNoThemeID() error {
 
 	if len(conf.Password) == 0 {
 		errors = append(errors, "missing password")
+	}
+
+	var symlinkErr error
+	conf.Directory, symlinkErr = filepath.EvalSymlinks(filepath.Clean(conf.Directory))
+	if symlinkErr != nil {
+		errors = append(errors, fmt.Sprintf("invalid project directory: %s", symlinkErr.Error()))
 	}
 
 	if len(errors) > 0 {

--- a/kit/file_watcher.go
+++ b/kit/file_watcher.go
@@ -59,17 +59,12 @@ func newFileWatcher(client ThemeClient, notifyFile string, recur bool, filter fi
 }
 
 func (watcher *FileWatcher) watch() error {
-	root, symlinkErr := filepath.EvalSymlinks(filepath.Clean(watcher.client.Config.Directory))
-	if symlinkErr != nil {
-		return symlinkErr
-	}
-
-	return filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+	return filepath.Walk(watcher.client.Config.Directory, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
 
-		if info.IsDir() && !watcher.filter.matchesFilter(path) && path != root {
+		if info.IsDir() && !watcher.filter.matchesFilter(path) && path != watcher.client.Config.Directory {
 			if err := watcher.mainWatcher.Add(path); err != nil {
 				return fmt.Errorf("Could not watch directory %s: %s", path, err)
 			}

--- a/kit/file_watcher_test.go
+++ b/kit/file_watcher_test.go
@@ -42,23 +42,23 @@ func TestFileWatcher_WatchSymlinkDirectory(t *testing.T) {
 	kittest.GenerateProject()
 	defer kittest.Cleanup()
 	filter, _ := newFileFilter(kittest.SymlinkProjectPath, []string{}, []string{})
+	config, err := (&Configuration{
+		ThemeID:   "123",
+		Password:  "abc123",
+		Domain:    "test.myshopify.com",
+		Directory: kittest.SymlinkProjectPath,
+	}).compile(true)
+	assert.Nil(t, err)
+	println(config.Directory)
+
 	w, _ := fsnotify.NewWatcher()
 	watcher := &FileWatcher{
 		filter:      filter,
 		mainWatcher: w,
-		client:      ThemeClient{Config: &Configuration{Directory: kittest.SymlinkProjectPath}},
+		client:      ThemeClient{Config: config},
 	}
 	assert.Nil(t, watcher.watch())
 	assert.Nil(t, watcher.mainWatcher.Remove(filepath.Join(kittest.FixtureProjectPath, "assets")))
-	watcher.StopWatching()
-
-	os.Remove(kittest.SymlinkProjectPath)
-	os.Symlink("nope", kittest.SymlinkProjectPath)
-	_, err := newFileFilter(kittest.SymlinkProjectPath, []string{}, []string{})
-	assert.NotNil(t, err)
-
-	watcher.client.Config.Directory = kittest.SymlinkProjectPath
-	assert.NotNil(t, watcher.watch())
 	watcher.StopWatching()
 }
 


### PR DESCRIPTION
fixes #447 possibly related to #454 

This will move symlink eval to config validation so that the whole codebase deals with one valid directory path.