### PR TITLE
Clarifying diff message

### DIFF
--- a/cmd/theme_diff.go
+++ b/cmd/theme_diff.go
@@ -33,8 +33,8 @@ Diff:
 {{- end }}
 
 You can solve this by running 'theme download' to get the most recent copy of these files.
-Running 'theme download' will overwrite any changes you have made so make your work is
-commit to your VCS before doing so.
+Running 'theme download' will overwrite any changes you have made so make sure your work is
+commited to your VCS before doing so.
 
 If you are certain that you want to overwrite any changes then use the --force flag
 `))

--- a/cmd/theme_diff.go
+++ b/cmd/theme_diff.go
@@ -32,9 +32,9 @@ Diff:
 		{{- end }}
 {{- end }}
 
-You can solve this by running theme download and merging the remote changes
-using your favourite diff tool or if you are certain about what you are doing
-then use the --force flag
+You can solve this by running theme download to get the most recent copy of this file. This will overwrite any local changes you have made
+
+f you are certain about what you are doing then use the --force flag
 `))
 
 func newDiff() *themeDiff {

--- a/cmd/theme_diff.go
+++ b/cmd/theme_diff.go
@@ -32,9 +32,11 @@ Diff:
 		{{- end }}
 {{- end }}
 
-You can solve this by running theme download to get the most recent copy of this file. This will overwrite any local changes you have made
+You can solve this by running 'theme download' to get the most recent copy of these files.
+Running 'theme download' will overwrite any changes you have made so make your work is
+commit to your VCS before doing so.
 
-f you are certain about what you are doing then use the --force flag
+If you are certain that you want to overwrite any changes then use the --force flag
 `))
 
 func newDiff() *themeDiff {

--- a/cmd/theme_diff_test.go
+++ b/cmd/theme_diff_test.go
@@ -27,8 +27,8 @@ Diff:
 		- testremoved.txt
 
 You can solve this by running 'theme download' to get the most recent copy of these files.
-Running 'theme download' will overwrite any changes you have made so make your work is
-commit to your VCS before doing so.
+Running 'theme download' will overwrite any changes you have made so make sure your work is
+commited to your VCS before doing so.
 
 If you are certain that you want to overwrite any changes then use the --force flag
 `

--- a/cmd/theme_diff_test.go
+++ b/cmd/theme_diff_test.go
@@ -26,9 +26,11 @@ Diff:
 	Removed Files:
 		- testremoved.txt
 
-You can solve this by running theme download and merging the remote changes
-using your favourite diff tool or if you are certain about what you are doing
-then use the --force flag
+You can solve this by running 'theme download' to get the most recent copy of these files.
+Running 'theme download' will overwrite any changes you have made so make your work is
+commit to your VCS before doing so.
+
+If you are certain that you want to overwrite any changes then use the --force flag
 `
 	assert.Equal(t, expected, diff.Error())
 }


### PR DESCRIPTION
rel: #456 

The diff message can be confusing and causes some users to be unaware that running `theme download` would overwrite their local changes. I am hoping to clarify any issues with this by re-writing this message.

@chrisbutcher @t-kelly Maybe you two can give me feedback on good verbiage for this?