### PR TITLE
Changing how the manifest deals with diff dates

### DIFF
--- a/cmd/bootstrap_test.go
+++ b/cmd/bootstrap_test.go
@@ -126,11 +126,11 @@ func TestSaveConfiguration(t *testing.T) {
 
 	kittest.GenerateConfig("example.myshopify.io", true)
 	env, _ := kit.LoadEnvironments("config.yml")
-	config, _ := env.GetConfiguration(kit.DefaultEnvironment, true)
+	config, _ := env.GetConfiguration(kit.DefaultEnvironment)
 	assert.Nil(t, saveConfiguration(config))
 
 	kittest.GenerateConfig("example.myshopify.io", false)
 	env, _ = kit.LoadEnvironments("config.yml")
-	config, _ = env.GetConfiguration(kit.DefaultEnvironment, true)
+	config, _ = env.GetConfiguration(kit.DefaultEnvironment)
 	assert.NotNil(t, saveConfiguration(config))
 }

--- a/cmd/command_arbiter_test.go
+++ b/cmd/command_arbiter_test.go
@@ -69,8 +69,6 @@ func TestCommandArbiter_GenerateThemeClients(t *testing.T) {
 	arbiter.disableIgnore = true
 	assert.Nil(t, arbiter.generateThemeClients(nil, []string{}))
 	assert.Equal(t, 1, len(arbiter.activeThemeClients))
-	assert.Equal(t, 3, len(arbiter.allThemeClients))
-	assert.Equal(t, 0, len(arbiter.allThemeClients[0].Config.IgnoredFiles))
 
 	arbiter.environments = stringArgArray{[]string{}}
 	assert.Nil(t, arbiter.generateThemeClients(nil, []string{}))

--- a/cmd/theme.go
+++ b/cmd/theme.go
@@ -82,11 +82,6 @@ func init() {
 	replaceCmd.Flags().BoolVarP(&arbiter.force, "force", "f", false, "disable version checking and force all changes")
 	uploadCmd.Flags().BoolVarP(&arbiter.force, "force", "f", false, "disable version checking and force all changes")
 
-	watchCmd.Flags().StringVarP(&arbiter.master, "master", "m", kit.DefaultEnvironment, "The destination from which all changes will be applied")
-	removeCmd.Flags().StringVarP(&arbiter.master, "master", "m", kit.DefaultEnvironment, "The destination from which all changes will be applied")
-	replaceCmd.Flags().StringVarP(&arbiter.master, "master", "m", kit.DefaultEnvironment, "The destination from which all changes will be applied")
-	uploadCmd.Flags().StringVarP(&arbiter.master, "master", "m", kit.DefaultEnvironment, "The destination from which all changes will be applied")
-
 	bootstrapCmd.Flags().StringVar(&bootstrapVersion, "version", latestRelease, "version of Shopify Timber to use")
 	bootstrapCmd.Flags().StringVar(&bootstrapPrefix, "prefix", "", "prefix to the Timber theme being created")
 	bootstrapCmd.Flags().StringVar(&bootstrapURL, "url", "", "a url to pull a project theme zip file from.")

--- a/kit/configuration.go
+++ b/kit/configuration.go
@@ -59,15 +59,13 @@ func SetFlagConfig(config Configuration) {
 // formatted configuration along with any validation errors. The config precedence
 // is flags, environment variables, then the config file.
 func NewConfiguration() (*Configuration, error) {
-	return (&Configuration{}).compile(true)
+	return (&Configuration{}).compile()
 }
 
-func (conf *Configuration) compile(active bool) (*Configuration, error) {
+func (conf *Configuration) compile() (*Configuration, error) {
 	newConfig := &Configuration{}
-	if active {
-		mergo.Merge(newConfig, &flagConfig)
-		mergo.Merge(newConfig, &environmentConfig)
-	}
+	mergo.Merge(newConfig, &flagConfig)
+	mergo.Merge(newConfig, &environmentConfig)
 	mergo.Merge(newConfig, conf)
 	mergo.Merge(newConfig, &defaultConfig)
 	return newConfig, newConfig.Validate()

--- a/kit/configuration_test.go
+++ b/kit/configuration_test.go
@@ -56,20 +56,16 @@ func TestConfiguration_Precedence(t *testing.T) {
 	defer resetConfig()
 
 	config := &Configuration{Password: "file"}
-	config, _ = config.compile(true)
+	config, _ = config.compile()
 	assert.Equal(t, "file", config.Password)
 
 	environmentConfig = Configuration{Password: "environment"}
-	config, _ = config.compile(true)
+	config, _ = config.compile()
 	assert.Equal(t, "environment", config.Password)
 
 	flagConfig = Configuration{Password: "flag"}
-	config, _ = config.compile(true)
+	config, _ = config.compile()
 	assert.Equal(t, "flag", config.Password)
-
-	config = &Configuration{Password: "file"}
-	config, _ = config.compile(false)
-	assert.Equal(t, "file", config.Password)
 }
 
 func TestConfiguration_Validate(t *testing.T) {

--- a/kit/environments.go
+++ b/kit/environments.go
@@ -66,7 +66,7 @@ func (e Environments) SetConfiguration(environmentName string, conf *Configurati
 // active parameter indicates if the configuration should take configuration values from
 // environment and flags. This is considered active because passive configurations only
 // take configuration from the config file and defaults.
-func (e Environments) GetConfiguration(environmentName string, active bool) (*Configuration, error) {
+func (e Environments) GetConfiguration(environmentName string) (*Configuration, error) {
 	conf, exists := e[environmentName]
 	if !exists {
 		return conf, fmt.Errorf("%s does not exist in this environments list", environmentName)
@@ -78,7 +78,7 @@ Please see %s for examples`,
 			blue("http://shopify.github.io/themekit/configuration/#config-file"))
 	}
 	conf.Environment = environmentName
-	return conf.compile(active)
+	return conf.compile()
 }
 
 // Save will write out the environment to a file.

--- a/kit/environments_test.go
+++ b/kit/environments_test.go
@@ -64,12 +64,12 @@ func TestEnvironments_GetConfiguration(t *testing.T) {
 	kittest.GenerateConfig("example.myshopify.io", true)
 	envs, err := LoadEnvironments("config.yml")
 	assert.Nil(t, err)
-	_, err = envs.GetConfiguration("development", true)
+	_, err = envs.GetConfiguration("development")
 	assert.Nil(t, err)
-	_, err = envs.GetConfiguration("nope", true)
+	_, err = envs.GetConfiguration("nope")
 	assert.NotNil(t, err)
 	envs["test"] = nil
-	_, err = envs.GetConfiguration("test", true)
+	_, err = envs.GetConfiguration("test")
 	assert.NotNil(t, err)
 }
 

--- a/kit/file_watcher_test.go
+++ b/kit/file_watcher_test.go
@@ -47,7 +47,7 @@ func TestFileWatcher_WatchSymlinkDirectory(t *testing.T) {
 		Password:  "abc123",
 		Domain:    "test.myshopify.com",
 		Directory: kittest.SymlinkProjectPath,
-	}).compile(true)
+	}).compile()
 	assert.Nil(t, err)
 	println(config.Directory)
 

--- a/kit/version.go
+++ b/kit/version.go
@@ -14,7 +14,7 @@ import (
 
 var (
 	// ThemeKitVersion is the version build of the library
-	ThemeKitVersion, _ = version.NewVersion("0.7.3")
+	ThemeKitVersion, _ = version.NewVersion("0.7.4")
 	// ThemeKitReleasesURL is the url that fetches all versions of themekit used for.
 	// updating themekit. Change this for testing reasons.
 	ThemeKitReleasesURL = "https://shopify-themekit.s3.amazonaws.com/releases/all.json"


### PR DESCRIPTION
fixes #459, #461, #462
possibly related: https://github.com/Shopify/themekit/issues/460

When this was first designed, I made the assumption that the developer would develop on one branch and then upload others. When they did so I would compare timestamps from development to deploy. This is incorrect. The timestamps should only ever be set in the manifest when a change has been made specifically on that file in that environment because that is the only time we are certain that we have captured the state accurately.

As such themekit no longer loads all environments, and so this will fix the issue with the environment variables and all the issues with shared configuration. This also just simplifies how themekit interacts with the config and makes it more predictable.