### PR TITLE
Fixing over zelous manifest pruning

### DIFF
--- a/cmd/file_manifest.go
+++ b/cmd/file_manifest.go
@@ -97,17 +97,6 @@ func (manifest *fileManifest) prune(clients []kit.ThemeClient) error {
 		}
 	}
 
-	// prune environments that no longer exist
-	for filename, envs := range manifest.local {
-		for envname := range envs {
-			if i := indexOf(len(clients), func(i int) bool { return clients[i].Config.Environment == envname }); i == -1 {
-				if err := manifest.store.Delete(filename, envname); err != nil {
-					return err
-				}
-			}
-		}
-	}
-
 	var err error
 	manifest.local, err = manifest.store.Dump()
 	return err

--- a/cmd/file_manifest_test.go
+++ b/cmd/file_manifest_test.go
@@ -57,13 +57,7 @@ func TestFileManifest_Prune(t *testing.T) {
 		remote: map[string]map[string]string{},
 	}
 	kittest.TouchFixtureFile("asset.js", "")
-	assert.Equal(t, ystore.ErrorCollectionNotFound, manifest.prune(arbiter.activeThemeClients))
-
-	store.Write(file, "other", now)
 	assert.Nil(t, manifest.prune(arbiter.activeThemeClients))
-
-	_, ok := manifest.local[file]["other"]
-	assert.False(t, ok)
 
 	manifest.local = map[string]map[string]string{"": {env: now}}
 	assert.NotNil(t, manifest.prune(arbiter.activeThemeClients))

--- a/cmd/ystore/ystore.go
+++ b/cmd/ystore/ystore.go
@@ -217,11 +217,7 @@ func (store *YStore) read() error {
 
 	store.mutex.Lock()
 	defer store.mutex.Unlock()
-	if err = yaml.Unmarshal(contents, &store.data); err != nil {
-		return err
-	}
-
-	return nil
+	return yaml.Unmarshal(contents, &store.data)
 }
 
 func (store *YStore) flush() error {

--- a/kittest/config.go
+++ b/kittest/config.go
@@ -122,8 +122,5 @@ func GenerateJSONConfig(domain string) error {
 		return err
 	}
 	data := struct{ Domain, Directory string }{domain, FixtureProjectPath}
-	if err = jsonConfig.Execute(f, data); err != nil {
-		return err
-	}
-	return nil
+	return jsonConfig.Execute(f, data)
 }


### PR DESCRIPTION
fixes #466 

In the previous version, the functionality to load all valid environments was taken out however the manifest pruning that checked the environments was not removed. This PR removes that extra pruning that is no longer needed