### PR TITLE
Adding desktop notifications to the watch command

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -3,6 +3,10 @@ import:
 - package: github.com/fatih/color
   version: ^1.0.0
 - package: github.com/inconshreveable/go-update
+- package: github.com/0xAX/notificator
+  repo: github.com/0xax/notificator
+  vcs: git
+  version: master
 - package: github.com/ryanuber/go-glob
   version: ^0.1.0
 - package: github.com/spf13/cobra


### PR DESCRIPTION
### Adding desktop notifications to the watch command
I was running a `theme watch` and I had an error in my liquid template and I did not notice. However, this error was caught by the logs in the watch.  So this pull request is going provide a desktop notification when the watch command starts and also if there is an error in any liquid template.

I use [Laravel Mix](https://github.com/JeffreyWay/laravel-mix) for compiling my CSS/JS using webpack and they have desktop notifications whenever the watch start and whenever there is an error and I found it very helpful.

Here is screenshot how it looks right now:

![screen shot 2017-11-03 at 3 13 31 pm](https://user-images.githubusercontent.com/6808460/32398291-a4f7550e-c0ab-11e7-9ed9-00451a0df397.png)


![screen shot 2017-11-03 at 3 28 40 pm](https://user-images.githubusercontent.com/6808460/32398294-b303b4da-c0ab-11e7-95e5-76bc0fe52fa4.png)

### Checklist

- [x] It is safe to simply rollback this change (e.g. changes to `theme.lock` that might corrupt a users workflow).
- [x] I have :tophat:'d these changes by using the commands I changed by hand
- [ ] I have run successfully run linting and tests on the codebase. **I could not run make check, it gave me some error**
- [ ] I have added tests for the changes I have made.  **I do not think is need it**
- [x] I have added a dependency to the project


### Things that can improve this PR
- We could change the icon to be Shopify icon
- We could consider adding a desktop notification whenever anything gets upload it.
