### PR TITLE
Use try-catch to exit PowerShell script on error

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -2,7 +2,14 @@
 $latest_release_url = "https://shopify-themekit.s3.amazonaws.com/releases/latest.json"
 
 Write-Output "Fetching release data";
-$release = $web_client.DownloadString($latest_release_url) | ConvertFrom-Json
+Try {
+  $release = $web_client.DownloadString($latest_release_url) | ConvertFrom-Json
+} Catch {
+  Write-Output "Couldn't fetch release data";
+  Write-Host -foreground Yellow -background Black "Couldn't fetch release data. Check your internet connection.";
+  Write-Host -foreground Red    -background Black "Error: $($PSItem.Exception.Message)";
+  Exit 1
+}
 
 $destFolder = "C:\Program Files (x86)\Theme Kit"
 if ([System.Environment]::Is64BitOperatingSystem) {
@@ -10,21 +17,42 @@ if ([System.Environment]::Is64BitOperatingSystem) {
 }
 $dest = "$($destFolder)\theme.exe"
 
-New-Item -ItemType Directory -Force -Path $destFolder | Out-Null
+Try {
+  New-Item -ItemType Directory -Force -Path $destFolder | Out-Null
+} Catch {
+  Write-Output "Couldn't create directory ""$($destFolder)""";
+  Write-Host -foreground Yellow -background Black "Couldn't create directory ""$($destFolder)"". Make sure you have Administrator access.";
+  Write-Host -foreground Red    -background Black "Error: $($PSItem.Exception.Message)";
+  Exit 1
+}
 
 foreach($platform in $release.platforms) {
   if (($platform.name -eq "windows-amd64" -And [System.Environment]::Is64BitOperatingSystem) -Or
     ($platform.name -eq "windows-386" -And ![System.Environment]::Is64BitOperatingSystem)) {
     Write-Output "Downloading version $($release.version) of Shopify Themekit.";
-    $web_client.DownloadFile($platform.url, $dest)
+    Try {
+      $web_client.DownloadFile($platform.url, $dest)
+    } Catch {
+      Write-Output "Couldn't download Shopify Themekit";
+      Write-Host -foreground Yellow -background Black "Couldn't download Shopify Themekit. Check your internet connection.";
+      Write-Host -foreground Red    -background Black "Error: $($PSItem.Exception.Message)";
+      Exit 1
+    }
   }
 }
 
 Write-Output "Setting Environment Variable";
-[Environment]::SetEnvironmentVariable(
-  "Path",
-  "$($env:Path);$($destFolder)",
-  [EnvironmentVariableTarget]::Machine
-)
+Try {
+  [Environment]::SetEnvironmentVariable(
+    "Path",
+    "$($env:Path);$($destFolder)",
+    [EnvironmentVariableTarget]::Machine
+  )
+} Catch {
+  Write-Output "Couldn't set environment variable";
+  Write-Host -foreground Yellow -background Black "Couldn't set environment variable. Make sure you have Administrator access.";
+  Write-Host -foreground Red    -background Black "Error: $($PSItem.Exception.Message)";
+  Exit 1
+}
 
 Write-Output "Install Complete. Please restart your Powershell.";


### PR DESCRIPTION
### WHAT are you trying to accomplish with this PR?

Use try-catch to exit PowerShell script on error condition (abnormal circumstances).

Script should not continue and report "Install Complete" when there is an error. Instead, it should print out an error message and exit with an exit code indicating failure.

Note that `Write-Output` writes to the pipeline while `Write-Host` writes to the host terminal (usually the user's screen). Only `Write-Host` provides coloring options. _(We should be using `Write-Host` for all messages, but I didn't change that here. I can open another PR for that.)_

### Checklist

- [ ] This changes the interface and requires a Major/Minor version change.
- [x] It is safe to simply rollback this change (e.g. changes to `theme.lock` that might corrupt a users workflow).
- [ ] I have :tophat:'d these changes by using the commands I changed by hand. _(what does tophatting mean?)_
- [x] I have run successfully run linting and tests on the codebase. _(script execution was tested)_
- [ ] I have added tests for the changes I have made.
- [ ] I have added a dependency to the project.

_(I'm not sure of the relevancy of some of the checklist items, as I'm changing the PowerShell script only. Please let me know if you need more info.)_

Mentions: @tanema, @chrisbutcher