### PR TITLE
Making python2 requirment clear at installation

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -44,4 +44,7 @@ class Installer(object):
             themefile.write(data)
         os.chmod(self.bin_path, 0o755)
 
-Installer()
+if sys.version_info[0] < 3:
+    Installer()
+else:
+    sys.exit("Python 2 is required for this script.")


### PR DESCRIPTION
fixes #508 

### WHAT are you trying to accomplish with this PR?
It isn't immediately clear that python2 is required for the installation script. This adds a check for the python version so that the error can be more appropriate. 

### Checklist

- [ ] This changes the interface and requires a Major/Minor version change.
- [x] It is safe to simply rollback this change (e.g. changes to `theme.lock` that might corrupt a users workflow).
- [x] I have :tophat:'d these changes by using the commands I changed by hand
