### PR TITLE
Dont validate all envs on load

### DIFF
--- a/src/cmdutil/util_test.go
+++ b/src/cmdutil/util_test.go
@@ -89,11 +89,6 @@ func TestGenerateContexts(t *testing.T) {
 	assert.EqualError(t, err, "Could not load any valid environments")
 
 	client = new(mocks.ShopifyClient)
-	factory = func(*env.Env) (shopifyClient, error) { return client, nil }
-	_, err = generateContexts(factory, nil, Flags{ConfigPath: "_testdata/invalid_config.yml", Environments: stringArgArray{[]string{"other"}}}, []string{})
-	assert.EqualError(t, err, "invalid config invalid environment []: (invalid store domain must end in '.myshopify.com',missing password)")
-
-	client = new(mocks.ShopifyClient)
 	factory = func(*env.Env) (shopifyClient, error) { return client, fmt.Errorf("not today") }
 	_, err = generateContexts(factory, nil, Flags{ConfigPath: "_testdata/config.yml"}, []string{})
 	assert.EqualError(t, err, "not today")

--- a/src/env/conf.go
+++ b/src/env/conf.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"encoding/json"
 	"github.com/caarlos0/env"
@@ -67,7 +66,7 @@ func Load(configPath string) (Conf, error) {
 		}
 	}
 
-	return conf, conf.validate()
+	return conf, nil
 }
 
 // Set will set the environment value and then mixin any overrides passed in. The os
@@ -94,26 +93,6 @@ func (c *Conf) Get(name string, overrides ...Env) (*Env, error) {
 		return env, ErrEnvNotDefined
 	}
 	return newEnv(name, *env, append([]Env{c.osEnv}, overrides...)...)
-}
-
-func (c Conf) validate() error {
-	errors := []string{}
-
-	for _, env := range c.Envs {
-		if env == nil {
-			continue
-		}
-		err := env.validate()
-		if err != nil {
-			errors = append(errors, err.Error())
-		}
-	}
-
-	if len(errors) > 0 {
-		return fmt.Errorf("invalid config %v", strings.Join(errors, ","))
-	}
-
-	return nil
 }
 
 // Save will write out the config to a file.

--- a/src/env/conf_test.go
+++ b/src/env/conf_test.go
@@ -22,7 +22,6 @@ func TestLoad(t *testing.T) {
 	}{
 		{path: "_testdata/projectdir/valid_config.yml", err: ""},
 		{path: "_testdata/projectdir/bad_format.yml", err: ""},
-		{path: "_testdata/projectdir/invalid_config.yml", err: "invalid store domain"},
 		{path: "_testdata/projectdir/invalid_yaml.yml", err: "Invalid yaml found while loading the config file"},
 		{path: "_testdata/projectdir/config.json", err: ""},
 		{path: "_testdata/projectdir/bad_config.json", err: "Invalid json found while loading the config file"},


### PR DESCRIPTION
### WHAT are you trying to accomplish with this PR?
fixes #545 
Themekit was validating all environments on deploy and we really should only be validating the environments that are requested. This takes out validation of a whole configuration file and only validates when an environment is fetched.

### Checklist

- [ ] This changes the interface and requires a Major/Minor version change.
- [x] It is safe to simply rollback this change (e.g. changes to `theme.lock` that might corrupt a users workflow).
- [x] I have :tophat:'d these changes by using the commands I changed by hand
- [x] I have run successfully run linting and tests on the codebase (You may have to install `golint`
- [x] I have added tests for the changes I have made.
- [ ] I have added a dependancy to the project
