### PR TITLE
Checking windows paths during deploy

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"path/filepath"
 	"sync"
 
 	"github.com/spf13/cobra"
@@ -107,7 +108,7 @@ func generateActions(ctx cmdutil.Ctx) (map[string]file.Op, error) {
 			return assetsActions, err
 		}
 		for _, filename := range remoteFiles {
-			assetsActions[filename] = file.Remove
+			assetsActions[filepath.ToSlash(filename)] = file.Remove
 		}
 	}
 

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"path/filepath"
 	"sync"
 
 	"github.com/spf13/cobra"
@@ -118,7 +117,7 @@ func generateActions(ctx cmdutil.Ctx) (map[string]file.Op, error) {
 	}
 
 	for _, path := range localAssets {
-		assetsActions[filepath.ToSlash(path)] = file.Update
+		assetsActions[path] = file.Update
 	}
 	return assetsActions, nil
 }

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -108,7 +108,7 @@ func generateActions(ctx cmdutil.Ctx) (map[string]file.Op, error) {
 			return assetsActions, err
 		}
 		for _, filename := range remoteFiles {
-			assetsActions[filepath.ToSlash(filename)] = file.Remove
+			assetsActions[filename] = file.Remove
 		}
 	}
 
@@ -118,7 +118,7 @@ func generateActions(ctx cmdutil.Ctx) (map[string]file.Op, error) {
 	}
 
 	for _, path := range localAssets {
-		assetsActions[path] = file.Update
+		assetsActions[filepath.ToSlash(path)] = file.Update
 	}
 	return assetsActions, nil
 }

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -73,7 +73,7 @@ func TestReplace(t *testing.T) {
 func TestGenerateActions(t *testing.T) {
 	ctx, client, _, _, _ := createTestCtx()
 	ctx.Env.Directory = filepath.Join("_testdata", "projectdir")
-	client.On("GetAllAssets").Return([]string{"assets/logo.png"}, nil)
+	client.On("GetAllAssets").Return([]string{filepath.Join("assets", "logo.png")}, nil)
 	actions, err := generateActions(ctx)
 	assert.Nil(t, err)
 	assert.Equal(t, actions["assets/logo.png"], file.Remove)

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -73,12 +73,13 @@ func TestReplace(t *testing.T) {
 func TestGenerateActions(t *testing.T) {
 	ctx, client, _, _, _ := createTestCtx()
 	ctx.Env.Directory = filepath.Join("_testdata", "projectdir")
-	client.On("GetAllAssets").Return([]string{filepath.Join("assets", "logo.png")}, nil)
+	client.On("GetAllAssets").Return([]string{"assets/logo.png"}, nil)
 	actions, err := generateActions(ctx)
 	assert.Nil(t, err)
 	assert.Equal(t, actions["assets/logo.png"], file.Remove)
 	assert.Equal(t, actions["config/settings_data.json"], file.Update)
 	assert.Equal(t, actions["assets/app.js"], file.Update)
+	assert.Equal(t, len(actions), 3)
 	_, found := actions["assets/.gitkeep"]
 	assert.False(t, found)
 

--- a/src/shopify/asset.go
+++ b/src/shopify/asset.go
@@ -135,6 +135,7 @@ func loadAssetsFromDirectory(root, dir string, ignore func(path string) bool) (a
 		if err != nil {
 			return err
 		}
+		assetKey = filepath.ToSlash(assetKey)
 		if !ignore(assetKey) {
 			assets = append(assets, assetKey)
 		}

--- a/src/shopify/asset_test.go
+++ b/src/shopify/asset_test.go
@@ -92,7 +92,7 @@ func TestAsset_Contents(t *testing.T) {
 func TestLoadAssetsFromDirectory(t *testing.T) {
 	root := filepath.Join("_testdata", "project")
 	ignoreNone := func(path string) bool { return strings.Contains(path, ".gitkeep") }
-	selectOne := func(path string) bool { return path != filepath.Join("assets", "application.js") }
+	selectOne := func(path string) bool { return path != "assets/application.js" }
 
 	testcases := []struct {
 		path, err string


### PR DESCRIPTION
fixes #548 

When loading files from directories,  the filepaths were not correctly loaded and normalized on windows. This will normalize the paths

### Warn Checklist
- [ ] This changes the interface and requires a Major/Minor version change.
- [x] I have :tophat:'d these changes by using the commands I changed by hand.
- [ ] I have added a dependancy to the project.
