### PR TITLE
Adding checksum checks to install scripts

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-import os, urllib, json, sys
+import os, urllib, json, sys, hashlib
 
 class Installer(object):
     LATEST_RELEASE_URL = "https://shopify-themekit.s3.amazonaws.com/releases/latest.json"
@@ -30,14 +30,18 @@ class Installer(object):
             sys.exit("Please open an issue at https://github.com/Shopify/themekit/issues")
         return Installer.ARCH_MAPPING[arch_name]
 
-    def __findReleaseURL(self):
+    def __findReleasePlatform(self):
         for index, platform in enumerate(self.release['platforms']):
             if platform['name'] == self.arch:
-                return platform['url']
+                return platform
 
     def __download(self):
-        release_url = self.__findReleaseURL()
-        data = urllib.urlopen(release_url).read()
+        platform = self.__findReleasePlatform()
+        data = urllib.urlopen(platform['url']).read()
+        if hashlib.md5(data).hexdigest() != platform['digest']:
+            sys.exit("Downloaded binary did not match checksum.")
+        else:
+            print("Validated binary checksum")
         if not os.path.exists(self.install_path):
             os.makedirs(self.install_path)
         with open(self.bin_path, "wb") as themefile:

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -32,6 +32,13 @@ foreach($platform in $release.platforms) {
     Write-Output "Downloading version $($release.version) of Shopify Themekit.";
     Try {
       $web_client.DownloadFile($platform.url, $dest)
+
+      $hashFromFile = Get-FileHash $dest -Algorithm MD5
+      if ($hashFromFile.Hash -eq $platform.digest) {
+        Write-Host -ForegroundColor Green 'Validated binary checksum'
+      } else {
+        Write-Host -ForegroundColor Red 'Downloaded binary did not match checksum.'
+      }
     } Catch {
       Write-Output "Couldn't download Shopify Themekit";
       Write-Host -foreground Yellow -background Black "Couldn't download Shopify Themekit. Check your internet connection.";


### PR DESCRIPTION
fixes #541

As I closed this issue I realized the install scripts do not check the binary digests so I added this to both of the install scripts.

### Warn Checklist
- [ ] This changes the interface and requires a Major/Minor version change.
- [ ] I have :tophat:'d these changes by using the commands I changed by hand.
- [ ] I have added a dependancy to the project.
