### PR TITLE
Shutdown watching appropriately

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -40,7 +40,7 @@ var (
  exist on your local machine will be removed from shopify.
 
   Deprecation Notice: This command is deprecated in v0.8.0 and will be removed in
-	v0.8.1. Please use the 'deploy' command instead.
+	v1.0.0. Please use the 'deploy' command instead.
 
  For more documentation please see http://shopify.github.io/themekit/commands/#replace
  `,
@@ -58,7 +58,7 @@ var (
  to shopify.
 
   Deprecation Notice: This command is deprecated in v0.8.0 and will be removed in
-	v0.8.1. Please use the 'deploy' command instead.
+	v1.0.0. Please use the 'deploy' command instead.
 
  For more documentation please see http://shopify.github.io/themekit/commands/#upload
  `,

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -20,7 +20,7 @@ var bootstrapCmd = &cobra.Command{
  your config file and create a new theme id for you.
 
 	Deprecation Notice: This command is deprecated in v0.8.0 and will be removed in
-	v0.8.1. Please use the 'new' command instead.
+	v1.0.0. Please use the 'new' command instead.
 
  For more documentation please see http://shopify.github.io/themekit/commands/#bootstrap
   `,

--- a/src/file/watcher.go
+++ b/src/file/watcher.go
@@ -140,9 +140,7 @@ func (w *Watcher) Stop() {
 	if w.fsWatcher == nil {
 		return
 	}
-	// This is half assed because fsnotify sometimes deadlocks
-	// if it finishes before exit great if not garbage collection will do it.
-	go w.fsWatcher.Close()
+	w.fsWatcher.Close()
 }
 
 func (w *Watcher) onIdle() {


### PR DESCRIPTION
fixes #553 

There was a bug in fsnotify that didn't allow me to shutdown the watchers inline to avoid deadlocks. Since the bug was fixed, I can ensure that watching stops before ending the command.

### Warn Checklist
- [ ] This changes the interface and requires a Major/Minor version change.
- [x] I have :tophat:'d these changes by using the commands I changed by hand.
- [ ] I have added a dependancy to the project.
