### PR TITLE
Fixing disable ignores

### DIFF
--- a/src/cmdutil/util.go
+++ b/src/cmdutil/util.go
@@ -73,6 +73,11 @@ func createCtx(newClient clientFact, conf env.Conf, e *env.Env, flags Flags, arg
 		)
 	}
 
+	if flags.DisableIgnore {
+		e.IgnoredFiles = []string{}
+		e.Ignores = []string{}
+	}
+
 	client, err := newClient(e)
 	if err != nil {
 		return Ctx{}, err
@@ -109,11 +114,6 @@ func createCtx(newClient clientFact, conf env.Conf, e *env.Env, flags Flags, arg
 				break
 			}
 		}
-	}
-
-	if flags.DisableIgnore {
-		e.IgnoredFiles = []string{}
-		e.Ignores = []string{}
 	}
 
 	return Ctx{


### PR DESCRIPTION
fixes #564 

Themekit was clearing ignore but note before creating a theme client so the themeclient still had all of the ignore.

### Warn Checklist
- [ ] This changes the interface and requires a Major/Minor version change.
- [ ] I have :tophat:'d these changes by using the commands I changed by hand.
- [ ] I have added a dependancy to the project.
