### PR TITLE
Fixing updating compiled assets

### DIFF
--- a/src/shopify/theme_client.go
+++ b/src/shopify/theme_client.go
@@ -270,7 +270,8 @@ func (c Client) UpdateAsset(asset Asset) error {
 	if len(r.Errors) > 0 {
 		if _, ok := r.Errors["asset"]; ok {
 			if resp.StatusCode == 422 && strings.Contains(r.Errors["asset"][0], "Cannot overwrite generated asset") {
-				c.DeleteAsset(asset) // No need to check the error because if it fails then remove will be tried again.
+				// No need to check the error because if it fails then remove will be tried again.
+				c.DeleteAsset(Asset{Key: asset.Key + ".liquid"})
 				return c.UpdateAsset(asset)
 			}
 			return errors.New(toSentence(r.Errors["asset"]))

--- a/src/shopify/theme_client_test.go
+++ b/src/shopify/theme_client_test.go
@@ -351,7 +351,7 @@ func TestThemeClient_UpdateAsset(t *testing.T) {
 
 	m.On(
 		"Delete",
-		"/admin/themes/123/assets.json?asset%5Bkey%5D=filename.txt",
+		"/admin/themes/123/assets.json?asset%5Bkey%5D=filename.txt.liquid",
 	).Return(jsonResponse("{}", 200), nil)
 
 	m.On(


### PR DESCRIPTION
fixes #579 #577 

During update operation, if themekit gets an error from shopify that says "Cannot overwrite generated asset", it will try to delete the original asset and try again uploading the updated asset. It seems like the newest release lost the `.liquid` in the delete operation. Currently, since the delete, operation is never successful then the command that is being run, just hangs. I have added this back in to fix this problem. 

### Warn Checklist
- [ ] This changes the interface and requires a Major/Minor version change.
- [x] I have :tophat:'d these changes by using the commands I changed by hand.
- [ ] I have added a dependancy to the project.
