### PR TITLE
Adding a publish command to themekit

### DIFF
--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/Shopify/themekit/src/cmdutil"
+)
+
+var publishCmd = &cobra.Command{
+	Use:   "publish",
+	Short: "publish a theme",
+	Long: `Publish will update the theme to be your current publish theme. Select
+the theme you want to publish using the env flag.
+
+ For more documentation please see http://shopify.github.io/themekit/commands/#deploy
+ `,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return cmdutil.ForSingleClient(flags, args, publish)
+	},
+}
+
+func publish(ctx *cmdutil.Ctx) error {
+	return ctx.Client.PublishTheme()
+}

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -4,6 +4,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/Shopify/themekit/src/cmdutil"
+	"github.com/Shopify/themekit/src/colors"
 )
 
 var publishCmd = &cobra.Command{
@@ -20,5 +21,13 @@ the theme you want to publish using the env flag.
 }
 
 func publish(ctx *cmdutil.Ctx) error {
-	return ctx.Client.PublishTheme()
+	err := ctx.Client.PublishTheme()
+	if err == nil {
+		ctx.Log.Printf(
+			"[%s] Successfully published theme %s",
+			colors.Green(ctx.Env.Name),
+			colors.Green(ctx.Env.ThemeID),
+		)
+	}
+	return err
 }

--- a/cmd/publish_test.go
+++ b/cmd/publish_test.go
@@ -1,0 +1,12 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestPublish(t *testing.T) {
+	ctx, client, _, _, _ := createTestCtx()
+	client.On("PublishTheme").Return(nil)
+	publish(ctx)
+	client.AssertExpectations(t)
+}

--- a/cmd/theme.go
+++ b/cmd/theme.go
@@ -109,5 +109,5 @@ func init() {
 	getCmd.Flags().BoolVarP(&flags.List, "list", "l", false, "list available themes.")
 	deployCmd.Flags().BoolVarP(&flags.NoDelete, "nodelete", "n", false, "do no delete file on shopify diring deploy.")
 
-	ThemeCmd.AddCommand(openCmd, versionCmd, bootstrapCmd, newCmd, configureCmd, downloadCmd, removeCmd, updateCmd, uploadCmd, replaceCmd, watchCmd, getCmd, deployCmd)
+	ThemeCmd.AddCommand(publishCmd, openCmd, versionCmd, bootstrapCmd, newCmd, configureCmd, downloadCmd, removeCmd, updateCmd, uploadCmd, replaceCmd, watchCmd, getCmd, deployCmd)
 }

--- a/src/cmdutil/_mocks/ShopifyClient.go
+++ b/src/cmdutil/_mocks/ShopifyClient.go
@@ -134,16 +134,7 @@ func (_m *ShopifyClient) GetInfo() (shopify.Theme, error) {
 
 // PublishTheme provides a mock function with given fields:
 func (_m *ShopifyClient) PublishTheme() error {
-	ret := _m.Called()
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r1
+	return _m.Called().Error(0)
 }
 
 // GetShop provides a mock function with given fields:

--- a/src/cmdutil/_mocks/ShopifyClient.go
+++ b/src/cmdutil/_mocks/ShopifyClient.go
@@ -132,6 +132,20 @@ func (_m *ShopifyClient) GetInfo() (shopify.Theme, error) {
 	return r0, r1
 }
 
+// PublishTheme provides a mock function with given fields:
+func (_m *ShopifyClient) PublishTheme() error {
+	ret := _m.Called()
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r1
+}
+
 // GetShop provides a mock function with given fields:
 func (_m *ShopifyClient) GetShop() (shopify.Shop, error) {
 	ret := _m.Called()

--- a/src/cmdutil/interfaces.go
+++ b/src/cmdutil/interfaces.go
@@ -9,6 +9,7 @@ type shopifyClient interface {
 	GetShop() (shopify.Shop, error)
 	CreateNewTheme(string, string) (shopify.Theme, error)
 	GetInfo() (shopify.Theme, error)
+	PublishTheme() error
 	Themes() ([]shopify.Theme, error)
 	GetAllAssets() ([]string, error)
 	GetAsset(string) (shopify.Asset, error)

--- a/src/shopify/theme_client.go
+++ b/src/shopify/theme_client.go
@@ -28,6 +28,8 @@ var (
 	ErrZipPathRequired = errors.New("theme zip path is required")
 	// ErrInfoWithoutThemeID will be returned if GetInfo is called on a live theme
 	ErrInfoWithoutThemeID = errors.New("cannot get info without a theme id")
+	// ErrPublishWithoutThemeID will be returned if PublishTheme is called on a live theme
+	ErrPublishWithoutThemeID = errors.New("cannot publish a theme without a theme id set")
 	// ErrThemeNotFound will be returned if trying to get a theme that does not exist
 	ErrThemeNotFound = errors.New("requested theme was not found")
 	// ErrShopDomainNotFound will be returned if you are getting shop info on an invalid domain
@@ -202,7 +204,7 @@ func (c Client) GetInfo() (Theme, error) {
 // PublishTheme will update the theme to be role main
 func (c Client) PublishTheme() error {
 	if c.themeID == "" {
-		return errors.New("cannot publish a theme without a theme id set")
+		return ErrPublishWithoutThemeID
 	}
 
 	resp, err := c.http.Put(


### PR DESCRIPTION
Rel: #583 

This adds a publish command to themekit so that a developer can publish a theme without opening admin.

It can be used by running 

```
> theme publish --env=production
```

### Warn Checklist
- [ ] This changes the interface and requires a Major/Minor version change.
- [ ] I have :tophat:'d these changes by using the commands I changed by hand.
- [ ] I have added a dependancy to the project.
