### PR TITLE
fix directory config and debounce watcher events.

### DIFF
--- a/src/env/conf_test.go
+++ b/src/env/conf_test.go
@@ -67,6 +67,8 @@ func TestSearchConfigPath(t *testing.T) {
 }
 
 func TestConf_Set(t *testing.T) {
+	dir, _ := filepath.Abs(filepath.Join("..", "file"))
+
 	testcases := []struct {
 		name      string
 		initial   Env
@@ -77,7 +79,7 @@ func TestConf_Set(t *testing.T) {
 		{name: "", initial: Env{}, err: ErrInvalidEnvironmentName.Error()},
 		{name: "development", initial: Env{}, err: "invalid environment"},
 		{name: "development", initial: Env{Domain: "yes.myshopify.com", Password: "abc123"}, expected: Env{Name: "development", Domain: "yes.myshopify.com", Password: "abc123", Directory: Default.Directory, Timeout: Default.Timeout}},
-		{name: "development", initial: Env{Domain: "yes.myshopify.com", Password: "abc123", Directory: filepath.Join("..", "file")}, expected: Env{Name: "development", Domain: "yes.myshopify.com", Password: "abc123", Directory: filepath.Join("..", "file"), Timeout: Default.Timeout}},
+		{name: "development", initial: Env{Domain: "yes.myshopify.com", Password: "abc123", Directory: filepath.Join("..", "file")}, expected: Env{Name: "development", Domain: "yes.myshopify.com", Password: "abc123", Directory: dir, Timeout: Default.Timeout}},
 		{name: "development", initial: Env{Domain: "yes.myshopify.com", Password: "abc123"}, overrides: []Env{{ThemeID: "12345"}}, expected: Env{Name: "development", Domain: "yes.myshopify.com", Password: "abc123", ThemeID: "12345", Directory: Default.Directory, Timeout: Default.Timeout}},
 	}
 

--- a/src/env/env.go
+++ b/src/env/env.go
@@ -91,5 +91,13 @@ func validateDirectory(dir string) (finalDir string, errors []string) {
 	} else if !fi.Mode().IsDir() {
 		errors = append(errors, fmt.Sprintf("Directory config %v is not a directory: %v", dir, err))
 	}
+
+	if !filepath.IsAbs(dir) {
+		var err error
+		if dir, err = filepath.Abs(dir); err != nil {
+			errors = append(errors, fmt.Sprintf("Could not get absolute root bath: %v", err))
+		}
+	}
+
 	return dir, errors
 }

--- a/src/env/env_test.go
+++ b/src/env/env_test.go
@@ -2,6 +2,7 @@ package env
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -13,13 +14,14 @@ import (
 func TestEnvNew(t *testing.T) {
 	env, _ := newEnv("", Env{})
 	assert.Equal(t, Default, *env)
+	pwd, _ := os.Getwd()
 
 	osEnv := Env{
 		Name:         "Foobar",
 		Password:     "password",
 		ThemeID:      "themeid",
 		Domain:       "nope.myshopify.com",
-		Directory:    filepath.Join("..", "env"),
+		Directory:    filepath.Join(pwd, "env"),
 		IgnoredFiles: []string{"one", "two", "three"},
 		Proxy:        ":3000",
 		Ignores:      []string{"four", "five", "six"},


### PR DESCRIPTION
fixes #600 #599 

This has two fixes in it.
- Fix the directory config for watching a subdirectory
- Add a minimal amount of debouncing back into the new filewatcher.

The debouncing just simply drains the event channel after the poll interval happens and then deduplicates them.

### Warn Checklist
- [ ] This changes the interface and requires a Major/Minor version change.
- [ ] I have :tophat:'d these changes by using the commands I changed by hand.
- [ ] I have added a dependancy to the project.
