### PR TITLE
Disabling cgo to fix certificate issues

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -21,7 +21,7 @@ You can open a new issue on the github issues and describe the feature you would
 
 Requirements:
 
-- Go 1.11 or higher
+- Go 1.12 or higher
 
 You can setup your development environment by running the following:
 

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,14 @@
 .PHONY: build
 install: bundle ## Build and install the theme binary
-	@go install github.com/Shopify/themekit/cmd/theme;
+	@CGO_ENABLED=0 go install github.com/Shopify/themekit/cmd/theme;
 lint: # Lint all packages
 ifeq ("$(shell which golint 2>/dev/null)","")
-	@go get -u github.com/golang/lint/golint
+	@go get -u golang.org/x/lint/golint
 endif
 	@golint -set_exit_status ./...
 test: lint ## lint and test the code
-	@go test -race -cover -covermode=atomic ./...
+	@echo "Race & Coverage Tests" && go test -race -cover -covermode=atomic ./...
+	@echo "CGO Disable Tests" && CGO_ENABLED=0 go test ./...
 clean: ## Remove all temporary build artifacts
 	@rm -rf build && echo "project cleaned";
 all: clean bundle ## will build a binary for all platforms
@@ -22,7 +23,7 @@ all: clean bundle ## will build a binary for all platforms
 build:
 	@mkdir -p build/dist/${GOOS}-${GOARCH} && \
     echo "[${GOOS}-${GOARCH}] build started" && \
-		go build \
+		CGO_ENABLED=0 go build \
 			-ldflags="-s -w" \
 			-o build/dist/${GOOS}-${GOARCH}/theme${EXT} \
 			github.com/Shopify/themekit/cmd/theme && \


### PR DESCRIPTION
Related: #544 

This is in hopes of fixing the certificate issues, thanks to @Aeon investigation. This simply disables cgo while building themekit and adding tests for that situation.

This PR also has some fixes to try and mitigate a flaky test.

### Warn Checklist
- [ ] This changes the interface and requires a Major/Minor version change.
- [ ] I have :tophat:'d these changes by using the commands I changed by hand.
- [ ] I have added a dependancy to the project.
