### PR TITLE
Added a check for a valid version before all version uses

### DIFF
--- a/src/release/release.go
+++ b/src/release/release.go
@@ -123,6 +123,10 @@ func installLatest(latestURL string, install func(platform) error) error {
 }
 
 func installVersion(ver, releasesURL string, install func(platform) error) error {
+	if _, err := version.NewVersion(ver); err != nil {
+		return err
+	}
+
 	releases, err := fetchReleases(releasesURL)
 	if err != nil {
 		return err
@@ -163,6 +167,10 @@ func applyUpdate(platformRelease platform, targetPath string) error {
 }
 
 func update(ver, releasesURL, distDir string, force bool, u uploader) error {
+	if _, err := version.NewVersion(ver); err != nil {
+		return err
+	}
+
 	if !force {
 		requestedVersion, _ := version.NewVersion(ver)
 		if !requestedVersion.Equal(ThemeKitVersion) {
@@ -193,6 +201,10 @@ func update(ver, releasesURL, distDir string, force bool, u uploader) error {
 }
 
 func remove(ver, releaseURL string, u uploader) error {
+	if _, err := version.NewVersion(ver); err != nil {
+		return err
+	}
+
 	releases, err := fetchReleases(releaseURL)
 	if err != nil {
 		return err

--- a/src/release/release_test.go
+++ b/src/release/release_test.go
@@ -115,6 +115,7 @@ func TestInstallVersion(t *testing.T) {
 	}{
 		{in: "0.4.7"},
 		{in: "0.0.0", err: "version 0.0.0 not found"},
+		{in: "v.0.8.2", err: "Malformed version: v.0.8.2"},
 	}
 
 	for _, testcase := range testcases {
@@ -171,6 +172,7 @@ func TestUpdate(t *testing.T) {
 		{ver: ThemeKitVersion.String(), dir: filepath.Join("_testdata", "dist"), req: true, err: "version has already been deployed"},
 		{ver: ThemeKitVersion.String(), dir: filepath.Join("_testdata", "otherdist"), err: " "},
 		{ver: ThemeKitVersion.String(), dir: filepath.Join("_testdata", "dist")},
+		{ver: "v.0.8.2", err: "Malformed version: v.0.8.2"},
 	}
 
 	for _, testcase := range testcases {
@@ -209,6 +211,7 @@ func TestRemove(t *testing.T) {
 	}{
 		{ver: "12.34.56", err: "version has not be deployed"},
 		{ver: "0.4.7"},
+		{ver: "v.0.8.2", err: "Malformed version: v.0.8.2"},
 	}
 
 	for _, testcase := range testcases {


### PR DESCRIPTION
fixes #604 

There is an issue where if the user tries to update to a version that is invalid semver, themekit will panic. This adds a check before the use of any user-inputted version so that the rest of the release package can use it with confidence.

Sorry @batasrki I was already getting some themekit work done, so I did this really quick as well.