### PR TITLE
fixed typo in Windows Installation path

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 ---
+
 # Shopify Theme Kit
 
 Theme Kit is a command line tool for shopify themes. Download the application
@@ -8,10 +9,10 @@ and with a tiny bit of setup you’re off to the theme creation races.
 
 Using Theme Kit will enable you to
 
-* Upload Themes to Multiple Environments
-* Fast Uploads and Downloads
-* Watch for local changes and upload automatically to Shopify
-* Works on Windows, Linux and macOS
+- Upload Themes to Multiple Environments
+- Fast Uploads and Downloads
+- Watch for local changes and upload automatically to Shopify
+- Works on Windows, Linux and macOS
 
 ## Installation
 
@@ -34,36 +35,40 @@ brew install themekit
 ```
 
 ### Windows Automatic Powershell Installation
+
 Run the following commands in Powershell as Administrator.
+
 ```
 (New-Object System.Net.WebClient).DownloadString("https://shopify.github.io/themekit/scripts/install.ps1") | powershell -command -
 ```
 
 ### Manual Installation
 
-| OS     | Architecture | md5 checksums              |          |
-| :------| :------------| :------------------------- | :------- |
-| macOS  | 64-bit       | {{ site.darwinamd64sum }}  |  [download](https://shopify-themekit.s3.amazonaws.com/{{ site.themekitversion }}/darwin-amd64/theme)
-| Windows| 64-bit       | {{ site.windowsamd64sum }} |  [download](https://shopify-themekit.s3.amazonaws.com/{{ site.themekitversion }}/windows-amd64/theme.exe)
-| Windows| 32-bit       | {{ site.windows386sum }}   |  [download](https://shopify-themekit.s3.amazonaws.com/{{ site.themekitversion }}/windows-386/theme.exe)
-| Linux  | 64-bit       | {{ site.linuxamd64sum }}   |  [download](https://shopify-themekit.s3.amazonaws.com/{{ site.themekitversion }}/linux-amd64/theme)
-| Linux  | 32-bit       | {{ site.linux386sum }}     |  [download](https://shopify-themekit.s3.amazonaws.com/{{ site.themekitversion }}/linux-386/theme)
-| FreeBSD| 64-bit       | {{ site.freebsdamd64sum }} |  [download](https://shopify-themekit.s3.amazonaws.com/{{ site.themekitversion }}/freebsd-amd64/theme)
-| FreeBSD| 32-bit       | {{ site.freebsd386sum }}   |  [download](https://shopify-themekit.s3.amazonaws.com/{{ site.themekitversion }}/freebsd-386/theme)
+| OS      | Architecture | md5 checksums              |                                                                                                          |
+| :------ | :----------- | :------------------------- | :------------------------------------------------------------------------------------------------------- |
+| macOS   | 64-bit       | {{ site.darwinamd64sum }}  | [download](https://shopify-themekit.s3.amazonaws.com/{{ site.themekitversion }}/darwin-amd64/theme)      |
+| Windows | 64-bit       | {{ site.windowsamd64sum }} | [download](https://shopify-themekit.s3.amazonaws.com/{{ site.themekitversion }}/windows-amd64/theme.exe) |
+| Windows | 32-bit       | {{ site.windows386sum }}   | [download](https://shopify-themekit.s3.amazonaws.com/{{ site.themekitversion }}/windows-386/theme.exe)   |
+| Linux   | 64-bit       | {{ site.linuxamd64sum }}   | [download](https://shopify-themekit.s3.amazonaws.com/{{ site.themekitversion }}/linux-amd64/theme)       |
+| Linux   | 32-bit       | {{ site.linux386sum }}     | [download](https://shopify-themekit.s3.amazonaws.com/{{ site.themekitversion }}/linux-386/theme)         |
+| FreeBSD | 64-bit       | {{ site.freebsdamd64sum }} | [download](https://shopify-themekit.s3.amazonaws.com/{{ site.themekitversion }}/freebsd-amd64/theme)     |
+| FreeBSD | 32-bit       | {{ site.freebsd386sum }}   | [download](https://shopify-themekit.s3.amazonaws.com/{{ site.themekitversion }}/freebsd-386/theme)       |
 
 #### Linux & macOS
+
 - Download the themekit binary that works for your system.
 - Compare checksums of the binary by running `md5 theme`
 - Put the binary on your path. We recommend somewhere like `/usr/local/bin`
 - Ensure that it works as expected by running `theme version`
 
 #### Windows Installation
+
 - Create a folder inside `C:\Program Files` called `Theme Kit`
 - Download themekit (below) and copy the extracted program into `C:\Program Files\Theme Kit`
 - Navigate to `Control Panel > System and Security > System`. Another way to get there is to Right-Click on `My Computer` and choose the `properties` item
 - Look for the button or link called `Environment Variables`
 - In the second panel look for the item called `Path` and double-click on it. This should open a window with a text field that is overflowing with content.
-- Move your cursor all the way to the end and add the following: `;C:\Program Files\Theme Kit`
+- Move your cursor all the way to the end and add the following: `C:\Program Files\Theme Kit`
 - Click `OK` until all the windows are gone.
 - To verify that Theme Kit has been installed, open `cmd.exe` and type in `theme`.
 
@@ -74,9 +79,8 @@ between your store and Theme Kit. The API key allows Theme Kit to talk to and ac
 your store, as well as its theme files.
 
 To do so, log into the Shopify store, and create a private app. In the Shopify
-Admin, go to Apps and click on `Manage private apps`. From there, click `Create a
-new private app`, to create your private app. Fill out the information at the top
-and set the permissions of **Theme templates and theme assets** to have ***Read and write***
+Admin, go to Apps and click on `Manage private apps`. From there, click `Create a new private app`, to create your private app. Fill out the information at the top
+and set the permissions of **Theme templates and theme assets** to have **_Read and write_**
 access. Press `Save` and you will be presented with the next screen. In it you will
 see your access credentials. Please copy the password. You will need it later.
 
@@ -91,11 +95,11 @@ theme new --password=[your-password] --store=[your-store.myshopify.com] --name=[
 ```
 
 This will:
+
 - generate a basic theme template locally
 - create a theme on shopify
 - upload the new files to shopify
 - Create/update your config file with the configuration for your new theme.
-
 
 ## Configure an existing theme.
 


### PR DESCRIPTION
Changed the installation path from `;C:\Program Files\Theme Kit` to `C:\Program Files\Theme Kit`

### Warn Checklist
- [ ] This changes the interface and requires a Major/Minor version change.
- [ ] I have :tophat:'d these changes by using the commands I changed by hand.
- [ ] I have added a dependancy to the project.
