### PR TITLE
Adding documentation to the website for the environment flag

### DIFF
--- a/docs/_includes/sidebar.html
+++ b/docs/_includes/sidebar.html
@@ -22,6 +22,9 @@
     <a class="docs-nav__link {% if page.url == '/commands/' %}active{% endif %}" href="{{ '/commands' | prepend: site.baseurl }}">Commands</a>
     <ul class="docs-sub-nav">
       <li>
+        <a class="docs-nav__link" href="{{ '/commands/#using-environments' | prepend: site.baseurl }}">Using Environments</a>
+      </li>
+      <li>
         <a class="docs-nav__link" href="{{ '/commands/#configure' | prepend: site.baseurl }}">Configure</a>
       </li>
       <li>

--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -14,6 +14,19 @@ command by running:
 > theme [command] --help
 ```
 
+## Using Environments
+
+All of the following commands can be run with a selected environment from the configuration.
+This allows multiple configurations to be held in the same config file.
+Please see the [configuration documentation]({{ '/configuration/#config-file' | prepend: site.baseurl }}) for reference.
+
+To use these environments you must specify them by name with the `--env` flag or `-e` for short.
+The default environment is `development`. For example if you wanted to deploy to your production environment you could run
+
+```bash
+theme deploy --env=production
+```
+
 ## Configure
 
 Use this command to create or update configuration files. If you run the following


### PR DESCRIPTION
fixes #624 

This PR adds missing documentation for the env flag in all commands. This previously went missing because all global flags that are used for most configuration were moved to the configuration docs however the env flag is a special case because it is global but is not part of the config.

### Warn Checklist
- [ ] This changes the interface and requires a Major/Minor version change.
- [ ] I have :tophat:'d these changes by using the commands I changed by hand.
- [ ] I have added a dependancy to the project.
