### PR TITLE
Ensure Relative Directory Paths in Config

### DIFF
--- a/src/env/conf.go
+++ b/src/env/conf.go
@@ -143,6 +143,11 @@ func (c Conf) save(w io.Writer) error {
 		}
 		if env.Directory == Default.Directory {
 			env.Directory = ""
+		} else if env.Directory != "" {
+			configDir := filepath.Dir(c.path)
+			if rel, err := filepath.Rel(configDir, env.Directory); err == nil {
+				env.Directory = rel
+			}
 		}
 		if env.Timeout == Default.Timeout {
 			env.Timeout = 0


### PR DESCRIPTION
related #621 

Prior to this, themekit would save absolute paths when saving the
config. This will now ensure that if the absolute path can be resolved,
it will be resolved and saved so that the config will be much more
portable

### Warn Checklist
- [ ] This changes the interface and requires a Major/Minor version change.
- [x] I have :tophat:'d these changes by using the commands I changed by hand.
- [ ] I have added a dependancy to the project.
