### PR TITLE
[DNM] Experiment for Hackdays to use checksums on our asset APIs

### DIFF
--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -40,7 +40,7 @@ func remove(ctx *cmdutil.Ctx, removeFile func(string) error) error {
 		removeGroup.Add(1)
 		go func(filename string) {
 			defer removeGroup.Done()
-			perform(ctx, filename, file.Remove)
+			perform(ctx, filename, "", file.Remove)
 			removeFile(filepath.Join(ctx.Env.Directory, filename))
 		}(filename)
 	}

--- a/src/cmdutil/interfaces.go
+++ b/src/cmdutil/interfaces.go
@@ -11,9 +11,9 @@ type shopifyClient interface {
 	GetInfo() (shopify.Theme, error)
 	PublishTheme() error
 	Themes() ([]shopify.Theme, error)
-	GetAllAssets() ([]string, error)
+	GetAllAssets() (map[string]string, error)
 	GetAsset(string) (shopify.Asset, error)
-	UpdateAsset(shopify.Asset) error
+	UpdateAsset(shopify.Asset, string) error
 	DeleteAsset(shopify.Asset) error
 }
 

--- a/src/env/env.go
+++ b/src/env/env.go
@@ -60,7 +60,7 @@ func (env *Env) validate() error {
 
 	if len(env.Domain) == 0 {
 		errors = append(errors, "missing store domain")
-	} else if !strings.HasSuffix(env.Domain, "myshopify.com") {
+	} else if !strings.HasSuffix(env.Domain, "myshopify.com") && !strings.HasSuffix(env.Domain, "myshopify.io") {
 		errors = append(errors, "invalid store domain must end in '.myshopify.com'")
 	}
 

--- a/src/file/watcher.go
+++ b/src/file/watcher.go
@@ -15,6 +15,8 @@ import (
 type Op int
 
 const (
+	// Skip is an op used to basically noop any operation that might update or remove
+	Skip Op = -1
 	// Update is a file op where the file is updated
 	Update Op = iota
 	// Remove is a file op where the file is removed


### PR DESCRIPTION
This will not work on production shopify as this was done with a local running shopify server and an experimental branch.

### What this does

During deploy, watch and download, it will compare the checksums of the files on
shopify compared with local checksums and will skip files that are the same. It will
also pass the previous checksum in the requests to shopify in the
`checksum_lock` param to ensure the version being updated has not
changed since last observed. Lastly for json files, we compact them
before checksuming since that is how checksums are calculated on
shopify.
