### PR TITLE
Better download errors

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -44,9 +44,9 @@ func download(ctx *cmdutil.Ctx) error {
 			defer ctx.DoneTask()
 			defer downloadGroup.Done()
 			if asset, err := ctx.Client.GetAsset(filename); err != nil {
-				ctx.Err("[%s] error downloading asset: %s", colors.Green(ctx.Env.Name), err)
+				ctx.Err("[%s] error downloading %s: %s", colors.Green(ctx.Env.Name), colors.Blue(filename), err)
 			} else if err = asset.Write(ctx.Env.Directory); err != nil {
-				ctx.Err("[%s] error writing asset: %s", colors.Green(ctx.Env.Name), err)
+				ctx.Err("[%s] error writing %s: %s", colors.Green(ctx.Env.Name), colors.Blue(filename), err)
 			} else if ctx.Flags.Verbose {
 				ctx.Log.Printf("[%s] Successfully wrote %s to disk", colors.Green(ctx.Env.Name), colors.Blue(filename))
 			}

--- a/cmd/download_test.go
+++ b/cmd/download_test.go
@@ -18,7 +18,7 @@ func TestDownload(t *testing.T) {
 	client.On("GetAsset", mock.MatchedBy(func(string) bool { return true })).Return(shopify.Asset{}, nil).Times(len(allFilenames))
 	err := download(ctx)
 	assert.Nil(t, err)
-	assert.Contains(t, stdErr.String(), "error writing asset")
+	assert.Contains(t, stdErr.String(), "error writing assets/logo.png")
 
 	ctx, client, _, _, _ = createTestCtx()
 	client.On("GetAllAssets").Return(allFilenames, fmt.Errorf("server error"))
@@ -31,7 +31,7 @@ func TestDownload(t *testing.T) {
 	client.On("GetAllAssets").Return(allFilenames, nil)
 	client.On("GetAsset", mock.MatchedBy(func(string) bool { return true })).Return(shopify.Asset{}, fmt.Errorf("asset err"))
 	assert.Nil(t, download(ctx))
-	assert.Contains(t, stdErr.String(), "error downloading asset")
+	assert.Contains(t, stdErr.String(), "error downloading assets/logo.png")
 }
 
 func TestFilesToDownload(t *testing.T) {

--- a/src/env/env.go
+++ b/src/env/env.go
@@ -60,7 +60,7 @@ func (env *Env) validate() error {
 
 	if len(env.Domain) == 0 {
 		errors = append(errors, "missing store domain")
-	} else if !strings.HasSuffix(env.Domain, "myshopify.com") {
+	} else if !strings.HasSuffix(env.Domain, "myshopify.com") && !strings.HasSuffix(env.Domain, "myshopify.io") {
 		errors = append(errors, "invalid store domain must end in '.myshopify.com'")
 	}
 


### PR DESCRIPTION
related #631 

This just adds asset names to the error responses in download so that it is clear which files are raising errors.