### PR TITLE
Making the file watcher more flexible

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/mattn/go-colorable v0.0.0-20180310133214-efa589957cd0
 	github.com/mattn/go-isatty v0.0.4 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/radovskyb/watcher v1.0.2
+	github.com/radovskyb/watcher v1.0.6
 	github.com/ryanuber/go-glob v0.0.0-20160226084822-572520ed46db
 	github.com/shibukawa/configdir v0.0.0-20170330084843-e180dbdc8da0
 	github.com/skratchdot/open-golang v0.0.0-20160302144031-75fb7ed4208c

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/radovskyb/watcher v1.0.2 h1:9L5TsZUbo1nKhQEQPtICVc+x9UZQ6VPdBepLHyGw/bQ=
 github.com/radovskyb/watcher v1.0.2/go.mod h1:78okwvY5wPdzcb1UYnip1pvrZNIVEIh/Cm+ZuvsUYIg=
+github.com/radovskyb/watcher v1.0.6 h1:8WIQ9UxEYMZjem1OwU7dVH94DXXk9mAIE1i8eqHD+IY=
+github.com/radovskyb/watcher v1.0.6/go.mod h1:78okwvY5wPdzcb1UYnip1pvrZNIVEIh/Cm+ZuvsUYIg=
 github.com/ryanuber/go-glob v0.0.0-20160226084822-572520ed46db h1:ge9atzKq16843f793fDVxKUhmTb4H5muzjJQ6PgsnHg=
 github.com/ryanuber/go-glob v0.0.0-20160226084822-572520ed46db/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
 github.com/shibukawa/configdir v0.0.0-20170330084843-e180dbdc8da0 h1:Xuk8ma/ibJ1fOy4Ee11vHhUFHQNpHhrBneOCNHVXS5w=

--- a/src/file/watcher.go
+++ b/src/file/watcher.go
@@ -137,16 +137,15 @@ func (w *Watcher) onEvent(event watcher.Event) bool {
 }
 
 func (w *Watcher) translateEvent(event watcher.Event) []Event {
-	var events []Event
 	oldPath, currentPath := w.parsePath(event.Path)
 	if isEventType(event.Op, watcher.Rename, watcher.Move) {
-		events = append(events, Event{Op: Remove, Path: oldPath}, Event{Op: Update, Path: currentPath})
+		return []Event{{Op: Remove, Path: oldPath}, {Op: Update, Path: currentPath}}
 	} else if isEventType(event.Op, watcher.Remove) {
-		events = append(events, Event{Op: Remove, Path: currentPath})
+		return []Event{{Op: Remove, Path: currentPath}}
 	} else if isEventType(event.Op, watcher.Create, watcher.Write) {
-		events = append(events, Event{Op: Update, Path: currentPath})
+		return []Event{{Op: Update, Path: currentPath}}
 	}
-	return events
+	return []Event{}
 }
 
 func (w *Watcher) parsePath(path string) (old, current string) {

--- a/src/file/watcher_test.go
+++ b/src/file/watcher_test.go
@@ -21,8 +21,6 @@ func TestMain(m *testing.M) {
 
 func TestNewFileWatcher(t *testing.T) {
 	w := createTestWatcher(t)
-	filter, _ := NewFilter(filepath.Join("_testdata", "project"), []string{"config/"}, []string{})
-	assert.Equal(t, w.filter, filter)
 	assert.Equal(t, w.notify, "/tmp/notifytest")
 	assert.NotNil(t, w.fsWatcher)
 	assert.NotNil(t, w.Events)
@@ -61,10 +59,10 @@ func TestFileWatcher_filterHook(t *testing.T) {
 		{filename: "_testdata/project/templates", skip: true},
 	}
 
-	w := createTestWatcher(t)
+	hook := createTestFilterHook(t)
 	for i, testcase := range testcases {
 		info, _ := os.Stat(testcase.filename)
-		result := w.filterHook(info, testcase.filename)
+		result := hook(info, testcase.filename)
 		if testcase.skip {
 			assert.Equal(t, result, watcher.ErrSkip, fmt.Sprintf("testcase: %v", i))
 		} else {
@@ -213,4 +211,15 @@ func createTestWatcher(t *testing.T) *Watcher {
 	w, err := NewWatcher(e, filepath.Join("_testdata", "project", "config.yml"))
 	assert.Nil(t, err)
 	return w
+}
+
+func createTestFilterHook(t *testing.T) watcher.FilterFileHookFunc {
+	e := &env.Env{
+		Directory:    filepath.Join("_testdata", "project"),
+		IgnoredFiles: []string{"config/"},
+		Notify:       "/tmp/notifytest",
+	}
+	hook, err := filterHook(e, filepath.Join("_testdata", "project", "config.yml"))
+	assert.Nil(t, err)
+	return hook
 }

--- a/src/file/watcher_test.go
+++ b/src/file/watcher_test.go
@@ -26,8 +26,6 @@ func TestNewFileWatcher(t *testing.T) {
 	assert.Equal(t, w.notify, "/tmp/notifytest")
 	assert.NotNil(t, w.fsWatcher)
 	assert.NotNil(t, w.Events)
-	watchedFiles := w.fsWatcher.WatchedFiles()
-	assert.Equal(t, 14, len(watchedFiles))
 }
 
 func TestFileWatcher_Watch(t *testing.T) {
@@ -52,18 +50,40 @@ func TestFileWatcher_Watch(t *testing.T) {
 	w.Stop()
 }
 
+func TestFileWatcher_filterHook(t *testing.T) {
+	testcases := []struct {
+		skip     bool
+		filename string
+	}{
+		{filename: "_testdata/project/config/settings.json", skip: true},
+		{filename: "_testdata/project/config.yml", skip: false},
+		{filename: "_testdata/project/templates/template.liquid", skip: false},
+		{filename: "_testdata/project/templates", skip: true},
+	}
+
+	w := createTestWatcher(t)
+	for i, testcase := range testcases {
+		info, _ := os.Stat(testcase.filename)
+		result := w.filterHook(info, testcase.filename)
+		if testcase.skip {
+			assert.Equal(t, result, watcher.ErrSkip, fmt.Sprintf("testcase: %v", i))
+		} else {
+			assert.Nil(t, result, fmt.Sprintf("testcase: %v", i))
+		}
+	}
+}
+
 func TestFileWatcher_WatchFsEvents(t *testing.T) {
 	testcases := []struct {
-		filename      string
-		op            watcher.Op
-		shouldReceive bool
-		expectedOp    Op
+		filename   string
+		op         watcher.Op
+		expectedOp Op
 	}{
-		{shouldReceive: false, filename: "_testdata/project/config/settings.json", op: watcher.Write},
-		{shouldReceive: true, expectedOp: Update, filename: "_testdata/project/templates/template.liquid", op: watcher.Write},
-		{shouldReceive: true, expectedOp: Update, filename: "_testdata/project/templates/customers/test.liquid", op: watcher.Write},
-		{shouldReceive: true, expectedOp: Remove, filename: "_testdata/project/templates/customers/test.liquid", op: watcher.Remove},
-		{shouldReceive: true, expectedOp: Remove, filename: "_testdata/project/templates/customers/test.liquid", op: watcher.Rename},
+		{filename: "_testdata/project/config/settings.json", op: watcher.Write},
+		{expectedOp: Update, filename: "_testdata/project/templates/template.liquid", op: watcher.Write},
+		{expectedOp: Update, filename: "_testdata/project/templates/customers/test.liquid", op: watcher.Write},
+		{expectedOp: Remove, filename: "_testdata/project/templates/customers/test.liquid", op: watcher.Remove},
+		{expectedOp: Remove, filename: "_testdata/project/templates/customers/test.liquid", op: watcher.Rename},
 	}
 
 	w := createTestWatcher(t)
@@ -74,19 +94,9 @@ func TestFileWatcher_WatchFsEvents(t *testing.T) {
 		info, _ := os.Stat(testcase.filename)
 		w.fsWatcher.Event <- watcher.Event{Op: testcase.op, Path: testcase.filename, FileInfo: info}
 
-		if testcase.shouldReceive {
-			e := <-w.Events
-			assert.Contains(t, testcase.filename, e.Path)
-			assert.Equal(t, testcase.expectedOp, e.Op, fmt.Sprintf("got the wrong operation %v", i))
-		} else {
-			if !assert.False(t, len(w.Events) > 0, testcase.filename) {
-				<-w.Events
-			}
-		}
-
-		for len(w.Events) > 0 {
-			<-w.Events
-		}
+		e := <-w.Events
+		assert.Contains(t, testcase.filename, e.Path)
+		assert.Equal(t, testcase.expectedOp, e.Op, fmt.Sprintf("got the wrong operation %v", i))
 	}
 }
 
@@ -96,8 +106,6 @@ func TestFileWatcher_OnEvent(t *testing.T) {
 		op         watcher.Op
 		expectedOp []Op
 	}{
-		{expectedOp: []Op{}, filename: "_testdata/project/templates/customers", op: watcher.Write},
-		{expectedOp: []Op{}, filename: "_testdata/project/config/settings.json", op: watcher.Write},
 		{expectedOp: []Op{Update}, filename: "_testdata/project/templates/template.liquid", op: watcher.Write},
 		{expectedOp: []Op{Update}, filename: "_testdata/project/templates/customers/test.liquid", op: watcher.Create},
 		{expectedOp: []Op{Remove}, filename: "_testdata/project/templates/customers/test.liquid", op: watcher.Remove},


### PR DESCRIPTION
Fixes #608 

This PR changes from watching directories specifically to watching the root directory recursively and uses a filter hook to split concerns of events and filtering.

This will allow picking up files in new folders and makes our code a bit easier to test and understand.

### TODO
- [ ] ensure the new watcher normalizes windows paths
- [ ]  possibly remove/minimize `src/file/path.go` filepath normalization since we will be locked to the root directory and we *should* not have to worry about file descriptors anymore.

### Warn Checklist
- [ ] This changes the interface and requires a Major/Minor version change.
- [x] I have :tophat:'d these changes by using the commands I changed by hand.
- [ ] I have added a dependancy to the project.
