### PR TITLE
Adding a missing html tag

### DIFF
--- a/theme-template/layout/theme.liquid
+++ b/theme-template/layout/theme.liquid
@@ -1,4 +1,5 @@
 <!doctype html>
+<html>
 <head>
   <title>{{ page_title }}</title>
   <meta charset="utf-8">


### PR DESCRIPTION
fixes #652 

There was a missing html opening tag in the layout when generated. This fixes that.

### Warn Checklist
- [ ] This changes the interface and requires a Major/Minor version change.
- [ ] I have :tophat:'d these changes by using the commands I changed by hand.
- [ ] I have added a dependancy to the project.
