### PR TITLE
Fixing file filter for windows

### DIFF
--- a/src/file/filter.go
+++ b/src/file/filter.go
@@ -56,6 +56,7 @@ func NewFilter(rootDir string, patterns []string, files []string) (Filter, error
 
 // Match will return true if the file path has matched a pattern in this filter
 func (f Filter) Match(path string) bool {
+	path = toSlash(path)
 	if len(path) == 0 || !pathInProject(f.rootDir, path) {
 		return true
 	}
@@ -129,4 +130,8 @@ func patternsToRegexpsAndGlobs(patterns []string) ([]*regexp.Regexp, []string) {
 	}
 
 	return regexps, globs
+}
+
+func toSlash(path string) string {
+	return strings.ReplaceAll(path, `\`, "/")
 }

--- a/src/file/filter_test.go
+++ b/src/file/filter_test.go
@@ -29,12 +29,18 @@ func TestFilter_Match(t *testing.T) {
 		{glob: "*test.txt", input: "templates/test.txt", matches: true},
 		{glob: "*test.txt", input: "templates/foo/test.txt", matches: true},
 		{glob: "*test.txt", input: "/tmp/templates/foo/test.txt", matches: true},
+		{glob: "*test.txt", input: "templates\foo\test.txt", matches: true},
 		{glob: "*build/*", input: "templates/build/hello/world", matches: true},
+		{glob: "*assets/sass/*", input: `assets\sass\foo.sass`, matches: true},
 		{glob: "*.json", input: "templates/settings.json", matches: true},
 		{glob: "*.gif", input: "templates/world.gif", matches: true},
+		{glob: "*.gif", input: `templates\world.gif`, matches: true},
 		{glob: "*.gif", input: "templates/worldgifno", matches: false},
+		{glob: "*.gif", input: `templates\worldgifno`, matches: false},
 		{regexp: `\.bat`, input: "templates/hello.bat", matches: true},
+		{regexp: `\.bat`, input: `templates\hello.bat`, matches: true},
 		{regexp: `\.bat`, input: "templates/hellobatno", matches: false},
+		{regexp: `\.bat`, input: `templates\hellobatno`, matches: false},
 		{regexp: `\.bat`, input: "templates/hello.css", matches: false},
 		{glob: "*test.txt", input: "/not/in/project/test.txt", matches: true},
 		{glob: "*test.txt", input: "test.txt", matches: true},
@@ -49,11 +55,7 @@ func TestFilter_Match(t *testing.T) {
 		if testcase.glob != "" {
 			filter.globs = []string{testcase.glob}
 		}
-		if testcase.matches {
-			assert.True(t, filter.Match(testcase.input), testcase.input)
-		} else {
-			assert.False(t, filter.Match(testcase.input), testcase.input)
-		}
+		assert.Equal(t, testcase.matches, filter.Match(testcase.input), testcase.input)
 	}
 }
 


### PR DESCRIPTION
fixes #653 

There was a problem with filters on windows machines in the new version. Because we changed the watching functionality. This is because the old watching backend always passed unix type paths but the newer backend passes the paths according to OS. This coverts all paths to slash before filtering.

### Warn Checklist
- [ ] This changes the interface and requires a Major/Minor version change.
- [ ] I have :tophat:'d these changes by using the commands I changed by hand.
- [ ] I have added a dependancy to the project.
