### PR TITLE
Change application.scss to application.scss.liquid

### DIFF
--- a/theme-template/assets/application.scss
+++ b/theme-template/assets/application.scss
@@ -1,1 +1,0 @@
-// put your styles here

--- a/theme-template/assets/application.scss.liquid
+++ b/theme-template/assets/application.scss.liquid
@@ -1,0 +1,3 @@
+// Put your styles in this file.
+// Shopify will compile SCSS/SASS on each deploy.
+// Note: "@import" rules aren’t supported.


### PR DESCRIPTION
Creating a new theme recently, I found that the default `application.scss` file wasn't compiling, leaving me with a 404 error for what should have been the theme CSS file.

Some searching led to [this post](https://community.shopify.com/c/Shopify-Design/Scss-file-doesn-t-compile/m-p/464829/highlight/true#M120822) and on to [this blog post](https://www.shopify.com/partners/blog/a-beginners-guide-to-sass-with-shopify-part-3) that suggested the scss file needed a missing `.liquid` extension.

I changed the file to `application.scss.liquid` and it worked!

This PR proposes changing the file to be `application.scss.liquid` by default, and adds comments to flag that SASS gets compiled on deploy, and that `@import` isn't supported.
