### PR TITLE
Py3+ compatibility for install script

### DIFF
--- a/docs/scripts/install.py
+++ b/docs/scripts/install.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 '''
     File name: install
-    Author: Tim Anema
+    Author: Tim Anema, Jared McKnight
     Date created: Sep 29, 2016
-    Date last modified: Sep 14 2018
+    Date last modified: Feb 12 2020
     Python Version: 2.7+
     Description: Install script for themekit. It will download a release and make it executable
 '''

--- a/docs/scripts/install.py
+++ b/docs/scripts/install.py
@@ -4,10 +4,16 @@
     Author: Tim Anema
     Date created: Sep 29, 2016
     Date last modified: Sep 14 2018
-    Python Version: 2.7
+    Python Version: 2.7+
     Description: Install script for themekit. It will download a release and make it executable
 '''
-import os, urllib, json, sys, hashlib
+
+import os, json, sys, hashlib
+try:
+    from urllib.request import urlopen
+except ImportError:
+    from urllib import urlopen
+
 
 class Installer(object):
     LATEST_RELEASE_URL = "https://shopify-themekit.s3.amazonaws.com/releases/latest.json"
@@ -25,7 +31,7 @@ class Installer(object):
         self.bin_path = "%s/theme" % self.install_path
         self.arch = self.__getArch()
         print("Fetching release data")
-        self.release = json.loads(urllib.urlopen(Installer.LATEST_RELEASE_URL).read().decode("utf-8"))
+        self.release = json.loads(urlopen(Installer.LATEST_RELEASE_URL).read().decode("utf-8"))
         print("Downloading version %s of Shopify Themekit" % self.release['version'])
         self.__download()
         print("Theme Kit has been installed at %s" % self.bin_path)
@@ -47,7 +53,7 @@ class Installer(object):
 
     def __download(self):
         platform = self.__findReleasePlatform()
-        data = urllib.urlopen(platform['url']).read()
+        data = urlopen(platform['url']).read()
         if hashlib.md5(data).hexdigest() != platform['digest']:
             sys.exit("Downloaded binary did not match checksum.")
         else:
@@ -58,7 +64,9 @@ class Installer(object):
             themefile.write(data)
         os.chmod(self.bin_path, 0o755)
 
-if sys.version_info[0] < 3:
-    Installer()
-else:
-    sys.exit("Python 2 is required for this script.")
+
+path = '/usr/local/bin'
+if len(sys.argv) > 1:
+    path = sys.argv[1]
+
+Installer(path=path)


### PR DESCRIPTION
This allows the installer script to run under either Python 2 or 3, at the user's discretion, or with whatever happens to be installed on the system as the default version. As time goes by, Python 3 will be more commonly the default, and even the only, Python version pre-installed on most systems.

Additionally, it is now also possible to pass the desired install path as an argument when running the script, as the path was already accepted in the installer class, but not able to be passed to it without modifying the installer. Example: `./install.py <path/to/where/i/want/themekit/installed>` Of note, the default install path has not changed and will apply if the user doesn't specify one.

/cc @tanema 