### PR TITLE
Fix broken link

### DIFF
--- a/docs/faq/index.md
+++ b/docs/faq/index.md
@@ -9,7 +9,7 @@ You will need to use another tool to do this, however there are many options ava
 to you to suit all use cases.
 
 - [Prepros](https://prepros.io/)
-- [LivePage Chrome Plugin](https://chrome.google.com/webstore/detail/livepage/pilnojpmdoofaelbinaeodfpjheijkbh?hl=en-US)
+- [LivePage Chrome Plugin](https://livepage.mikerogers.io/)
 - [BrowserSync](https://www.browsersync.io/)
 - [LiveReload](http://livereload.com/)
 


### PR DESCRIPTION
**LivePage Chrome Plugin** doesn not exist anymore in the Chrome Web Store. It now needs to be built from the source code as [the website says](https://livepage.mikerogers.io/).

> As of the 10th of February 2020 is not actively maintained. You can still find the source code on GitHub if you'd like to use it.



### Warn Checklist
- [ ] This changes the interface and requires a Major/Minor version change.
- [ ] I have :tophat:'d these changes by using the commands I changed by hand.
- [ ] I have added a dependancy to the project.
