### PR TITLE
Add checksum to Asset model

### DIFF
--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -37,7 +37,8 @@ func TestUpload(t *testing.T) {
 	ctx.Flags.NoDelete = true
 	ctx.Env.Directory = "_testdata/projectdir"
 	ctx.Flags.Verbose = true
-	client.On("UpdateAsset", shopify.Asset{Key: "assets/app.js"}).Return(nil)
+	// This checksum corresponds to a zero-byte file
+	client.On("UpdateAsset", shopify.Asset{Key: "assets/app.js", Checksum: "d41d8cd98f00b204e9800998ecf8427e"}).Return(nil)
 	err = deploy(ctx)
 	assert.Nil(t, err)
 	assert.Contains(t, stdOut.String(), "Updated assets/app.js")

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -48,7 +48,13 @@ func download(ctx *cmdutil.Ctx) error {
 			} else if err = asset.Write(ctx.Env.Directory); err != nil {
 				ctx.Err("[%s] error writing %s: %s", colors.Green(ctx.Env.Name), colors.Blue(filename), err)
 			} else if ctx.Flags.Verbose {
-				ctx.Log.Printf("[%s] Successfully wrote %s to disk", colors.Green(ctx.Env.Name), colors.Blue(filename))
+				var checksumOutput = ""
+				if asset.Checksum != "" {
+					checksumOutput = "Checksum " + asset.Checksum
+				} else {
+					checksumOutput = "No checksum"
+				}
+				ctx.Log.Printf("[%s] Successfully wrote %s to disk (%s)", colors.Green(ctx.Env.Name), colors.Blue(filename), checksumOutput)
 			}
 		}(filename)
 	}

--- a/cmd/watch_test.go
+++ b/cmd/watch_test.go
@@ -48,7 +48,7 @@ func TestWatch(t *testing.T) {
 	signalChan = make(chan os.Signal)
 	eventChan = make(chan file.Event)
 	ctx, client, _, stdOut, stdErr := createTestCtx()
-	client.On("UpdateAsset", shopify.Asset{Key: "assets/app.js"}).Return(nil)
+	client.On("UpdateAsset", shopify.Asset{Key: "assets/app.js", Checksum: "d41d8cd98f00b204e9800998ecf8427e"}).Return(nil)
 	ctx.Flags.ConfigPath = "config.yml"
 	ctx.Env.Directory = "_testdata/projectdir"
 	go func() {
@@ -88,14 +88,14 @@ func TestPerform(t *testing.T) {
 
 	ctx, m, _, _, se = createTestCtx()
 	ctx.Env.Directory = "_testdata/projectdir"
-	m.On("UpdateAsset", shopify.Asset{Key: key}).Return(fmt.Errorf("shopify says no update"))
+	m.On("UpdateAsset", shopify.Asset{Key: key, Checksum: "d41d8cd98f00b204e9800998ecf8427e"}).Return(fmt.Errorf("shopify says no update"))
 	perform(ctx, key, file.Update)
 	assert.Contains(t, se.String(), "shopify says no update")
 	m.AssertExpectations(t)
 
 	ctx, m, _, so, _ := createTestCtx()
 	ctx.Env.Directory = "_testdata/projectdir"
-	m.On("UpdateAsset", shopify.Asset{Key: key}).Return(nil)
+	m.On("UpdateAsset", shopify.Asset{Key: key, Checksum: "d41d8cd98f00b204e9800998ecf8427e"}).Return(nil)
 	perform(ctx, key, file.Update)
 	assert.NotContains(t, so.String(), "Updated")
 	m.AssertExpectations(t)
@@ -103,7 +103,7 @@ func TestPerform(t *testing.T) {
 	ctx, m, _, so, _ = createTestCtx()
 	ctx.Env.Directory = "_testdata/projectdir"
 	ctx.Flags.Verbose = true
-	m.On("UpdateAsset", shopify.Asset{Key: key}).Return(nil)
+	m.On("UpdateAsset", shopify.Asset{Key: key, Checksum: "d41d8cd98f00b204e9800998ecf8427e"}).Return(nil)
 	perform(ctx, key, file.Update)
 	assert.Contains(t, so.String(), "Updated")
 	m.AssertExpectations(t)

--- a/src/shopify/_testdata/project/assets/app.json
+++ b/src/shopify/_testdata/project/assets/app.json
@@ -1,0 +1,1 @@
+{"testing" : "data"}

--- a/src/shopify/_testdata/project/assets/app_alternate.json
+++ b/src/shopify/_testdata/project/assets/app_alternate.json
@@ -1,0 +1,1 @@
+{"testing":"data"}

--- a/src/shopify/_testdata/project/assets/template.liquid
+++ b/src/shopify/_testdata/project/assets/template.liquid
@@ -1,0 +1,3 @@
+{% comment %}
+  The contents
+{% endcomment %}


### PR DESCRIPTION
Pairing with @ayronshopify

### What have we done
We've updated the Asset model to have a `Checksum` field so that we can process checksums in the future and calculate/compare them to the checksums from the Asset REST API.

We've added new tests for the Asset model to look at the various filetypes that we may encounter (`.liquid`, `.json`, `.js`). 

We've also added logging in the verbose (`-v`) mode for downloading which allows us to see the checksum for each file (as retrieved from the API). We think this will be useful for debugging or comparing checksums locally.

### Warn Checklist
- [x] ~This changes the interface and requires a Major/Minor version change.~ This new behaviour is not yet exposed externally, so should be a minor version bump.
- [x] I have :tophat:'d these changes by using the commands I changed by hand.
- [x] I have added a dependancy to the project. **crypto/md5**

### 🎩 Steps 

- [x] Set a file's checksum (e.g. through the Rails console)(
- [x] Run `theme download -v`
- [x] Verify the checksum is displayed next to the correct file