### PR TITLE
Ignore coverage.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ tags
 
 # for testing
 coverage.out
+coverage.txt
 
 # for docs
 docs/_site/


### PR DESCRIPTION
When running the test command from `.travis.yml` locally, this file is left behind.

### Warn Checklist
- [ ] This changes the interface and requires a Major/Minor version change.
- [ ] I have :tophat:'d these changes by using the commands I changed by hand.
- [ ] I have added a dependancy to the project.
