### PR TITLE
Skip download of files if checksums match

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -101,16 +101,21 @@ func generateActions(ctx *cmdutil.Ctx) (map[string]file.Op, error) {
 		return assetsActions, compiledAssetWarning(ctx.Env.Name, problemAssets)
 	}
 
-	for _, path := range localAssets {
+	for _, asset := range localAssets {
+		var path = asset.Key
 		assetsActions[path] = file.Update
 	}
 	return assetsActions, nil
 }
 
-func compileAssetFilenames(filenames []string) (problemAssets []string) {
+func compileAssetFilenames(assets []shopify.Asset) (problemAssets []string) {
+	var filenames []string
+	for _, asset := range assets {
+		filenames = append(filenames, asset.Key)
+	}
 	sort.Strings(filenames)
-	for i := 0; i < len(filenames)-1; i += 2 {
-		if filenames[i]+".liquid" == filenames[i+1] {
+	for i, filename := range filenames {
+		if i < len(filenames)-1 && filename+".liquid" == filenames[i+1] {
 			problemAssets = append(problemAssets, colors.Yellow(filenames[i])+
 				colors.Blue(" conflicts with ")+
 				colors.Yellow(filenames[i+1]))

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -115,15 +115,17 @@ func TestGenerateActions(t *testing.T) {
 }
 
 func TestCompileAssetFilenames(t *testing.T) {
-	input := []string{
-		"assets/app.js",
-		"assets/app.scss",
-		"assets/foo.js.liquid",
-		"assets/app.js.liquid",
-		"assets/foo.js",
+	input := []shopify.Asset{
+		{Key: "assets/app.js"},
+		{Key: "assets/app.scss"},
+		{Key: "assets/foo.js.liquid"},
+		{Key: "assets/app.js.liquid"},
+		{Key: "assets/foo.js"},
 	}
+
 	expected := []string{
 		colors.Yellow("assets/app.js") + colors.Blue(" conflicts with ") + colors.Yellow("assets/app.js.liquid"),
+		colors.Yellow("assets/foo.js") + colors.Blue(" conflicts with ") + colors.Yellow("assets/foo.js.liquid"),
 	}
 	assert.Equal(t, expected, compileAssetFilenames(input))
 }

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -46,7 +46,7 @@ func download(ctx *cmdutil.Ctx) error {
 			defer downloadGroup.Done()
 
 			localAsset, _ := shopify.ReadAsset(ctx.Env, requestAsset.Key)
-			if localAsset.Checksum == requestAsset.Checksum {
+			if localAsset.Checksum == requestAsset.Checksum && requestAsset.Checksum != "" {
 				ctx.Log.Printf("[%s] Skipped %s (%s)", colors.Green(ctx.Env.Name), colors.Blue(requestAsset.Key), localAsset.Checksum)
 			} else if asset, err := ctx.Client.GetAsset(requestAsset.Key); err != nil {
 				ctx.Err("[%s] error downloading %s: %s", colors.Green(ctx.Env.Name), colors.Blue(requestAsset.Key), err)
@@ -71,7 +71,7 @@ func download(ctx *cmdutil.Ctx) error {
 func filesToDownload(ctx *cmdutil.Ctx) ([]shopify.Asset, error) {
 	assets, err := ctx.Client.GetAllAssets()
 	if err != nil {
-		return assets, err
+		return []shopify.Asset{}, err
 	}
 
 	if len(ctx.Args) <= 0 {

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Shopify/themekit/src/cmdutil"
 	"github.com/Shopify/themekit/src/colors"
+	"github.com/Shopify/themekit/src/shopify"
 )
 
 var downloadCmd = &cobra.Command{
@@ -28,76 +29,75 @@ var downloadCmd = &cobra.Command{
 func download(ctx *cmdutil.Ctx) error {
 	var downloadGroup sync.WaitGroup
 
-	filenames, err := filesToDownload(ctx)
+	assets, err := filesToDownload(ctx)
 	if err != nil {
 		return err
 	}
 
-	if len(filenames) == 0 {
+	if len(assets) == 0 {
 		return fmt.Errorf("No files to download")
 	}
 
-	ctx.StartProgress(len(filenames))
-	for _, filename := range filenames {
+	ctx.StartProgress(len(assets))
+	for _, asset := range assets {
 		downloadGroup.Add(1)
-		go func(filename string) {
+		go func(requestAsset shopify.Asset) {
 			defer ctx.DoneTask()
 			defer downloadGroup.Done()
-			if asset, err := ctx.Client.GetAsset(filename); err != nil {
-				ctx.Err("[%s] error downloading %s: %s", colors.Green(ctx.Env.Name), colors.Blue(filename), err)
+
+			localAsset, _ := shopify.ReadAsset(ctx.Env, requestAsset.Key)
+			if localAsset.Checksum == requestAsset.Checksum {
+				ctx.Log.Printf("[%s] Skipped %s (%s)", colors.Green(ctx.Env.Name), colors.Blue(requestAsset.Key), localAsset.Checksum)
+			} else if asset, err := ctx.Client.GetAsset(requestAsset.Key); err != nil {
+				ctx.Err("[%s] error downloading %s: %s", colors.Green(ctx.Env.Name), colors.Blue(requestAsset.Key), err)
 			} else if err = asset.Write(ctx.Env.Directory); err != nil {
-				ctx.Err("[%s] error writing %s: %s", colors.Green(ctx.Env.Name), colors.Blue(filename), err)
+				ctx.Err("[%s] error writing %s: %s", colors.Green(ctx.Env.Name), colors.Blue(requestAsset.Key), err)
 			} else if ctx.Flags.Verbose {
 				var checksumOutput = ""
 				if asset.Checksum != "" {
-					checksumOutput = "Checksum " + asset.Checksum
+					checksumOutput = "Remote Checksum: " + requestAsset.Checksum + ", Local Checksum: " + localAsset.Checksum
 				} else {
-					checksumOutput = "No checksum"
+					checksumOutput = "No Checksum, Local Checksum " + localAsset.Checksum
 				}
-				ctx.Log.Printf("[%s] Successfully wrote %s to disk (%s)", colors.Green(ctx.Env.Name), colors.Blue(filename), checksumOutput)
+				ctx.Log.Printf("[%s] Successfully wrote %s to disk (%s)", colors.Green(ctx.Env.Name), colors.Blue(asset.Key), checksumOutput)
 			}
-		}(filename)
+		}(asset)
 	}
 
 	downloadGroup.Wait()
 	return nil
 }
 
-func filesToDownload(ctx *cmdutil.Ctx) ([]string, error) {
+func filesToDownload(ctx *cmdutil.Ctx) ([]shopify.Asset, error) {
 	assets, err := ctx.Client.GetAllAssets()
 	if err != nil {
-		return []string{}, err
-	}
-
-	allFilenames := make([]string, len(assets))
-	for i, asset := range assets {
-		allFilenames[i] = asset.Key
+		return assets, err
 	}
 
 	if len(ctx.Args) <= 0 {
-		return allFilenames, nil
+		return assets, nil
 	}
 
-	fetchableFilenames := []string{}
-	for _, filename := range allFilenames {
+	fetchableFiles := []shopify.Asset{}
+	for _, asset := range assets {
 		for _, pattern := range ctx.Args {
 			// These need to be converted to platform specific because filepath.Match
 			// uses platform specific separators
 			pattern = filepath.FromSlash(pattern)
-			filename = filepath.FromSlash(filename)
+			filename := filepath.FromSlash(asset.Key)
 
 			globMatched, _ := filepath.Match(pattern, filename)
 			dirMatched, _ := filepath.Match(pattern+string(filepath.Separator)+"*", filename)
 			fileMatched := filename == pattern
 			if globMatched || dirMatched || fileMatched {
-				fetchableFilenames = append(fetchableFilenames, filepath.ToSlash(filename))
+				fetchableFiles = append(fetchableFiles, asset)
 			}
 		}
 	}
 
-	if len(fetchableFilenames) == 0 {
-		return fetchableFilenames, fmt.Errorf("No file paths matched the inputted arguments")
+	if len(fetchableFiles) == 0 {
+		return fetchableFiles, fmt.Errorf("No file paths matched the inputted arguments")
 	}
 
-	return fetchableFilenames, nil
+	return fetchableFiles, nil
 }

--- a/cmd/download_test.go
+++ b/cmd/download_test.go
@@ -11,7 +11,16 @@ import (
 )
 
 func TestDownload(t *testing.T) {
-	allAssets := []shopify.Asset{{Key: "assets/logo.png"}, {Key: "templates/customers/test.liquid"}, {Key: "config/test.liquid"}, {Key: "layout/test.liquid"}, {Key: "snippets/test.liquid"}, {Key: "templates/test.liquid"}, {Key: "locales/test.liquid"}, {Key: "sections/test.liquid"}}
+	allAssets := []shopify.Asset{
+		{Key: "assets/logo.png"},
+		{Key: "templates/customers/test.liquid"},
+		{Key: "config/test.liquid"},
+		{Key: "layout/test.liquid"},
+		{Key: "snippets/test.liquid"},
+		{Key: "templates/test.liquid"},
+		{Key: "locales/test.liquid"},
+		{Key: "sections/test.liquid"},
+	}
 
 	ctx, client, _, _, stdErr := createTestCtx()
 	client.On("GetAllAssets").Return(allAssets, nil)

--- a/cmd/download_test.go
+++ b/cmd/download_test.go
@@ -45,22 +45,19 @@ func TestDownload(t *testing.T) {
 
 func TestFilesToDownload(t *testing.T) {
 	allAssets := []shopify.Asset{{Key: "assets/logo.png"}, {Key: "templates/customers/test.liquid"}, {Key: "config/test.liquid"}, {Key: "layout/test.liquid"}, {Key: "snippets/test.liquid"}, {Key: "templates/test.liquid"}, {Key: "locales/test.liquid"}, {Key: "sections/test.liquid"}}
-	allFilenames := []string{}
-	for _, asset := range allAssets {
-		allFilenames = append(allFilenames, asset.Key)
-	}
 
 	testcases := []struct {
-		err       string
-		respErr   error
-		args, ret []string
+		err     string
+		respErr error
+		args    []string
+		ret     []shopify.Asset
 	}{
-		{ret: allFilenames},
-		{args: []string{"assets/logo.png"}, ret: []string{"assets/logo.png"}},
-		{args: []string{"assets/*"}, ret: []string{"assets/logo.png"}},
-		{args: []string{"templates"}, ret: []string{"templates/test.liquid"}},
-		{args: []string{"assets/nope.png"}, ret: []string{}, err: "No file paths matched the inputted arguments"},
-		{args: []string{"assets/nope.png"}, ret: []string{}, respErr: fmt.Errorf("server error"), err: "server error"},
+		{ret: allAssets},
+		{args: []string{"assets/logo.png"}, ret: []shopify.Asset{{Key: "assets/logo.png"}}},
+		{args: []string{"assets/*"}, ret: []shopify.Asset{{Key: "assets/logo.png"}}},
+		{args: []string{"templates"}, ret: []shopify.Asset{{Key: "templates/test.liquid"}}},
+		{args: []string{"assets/nope.png"}, ret: []shopify.Asset{}, err: "No file paths matched the inputted arguments"},
+		{args: []string{"assets/nope.png"}, ret: []shopify.Asset{}, respErr: fmt.Errorf("server error"), err: "server error"},
 	}
 
 	for i, testcase := range testcases {

--- a/src/shopify/asset_test.go
+++ b/src/shopify/asset_test.go
@@ -90,7 +90,6 @@ func TestAsset_Contents(t *testing.T) {
 }
 
 func TestLoadAssetsFromDirectory(t *testing.T) {
-	root := filepath.Join("_testdata", "project")
 	ignoreNone := func(path string) bool { return strings.Contains(path, ".gitkeep") }
 	selectOne := func(path string) bool { return path != "assets/application.js" }
 
@@ -105,8 +104,9 @@ func TestLoadAssetsFromDirectory(t *testing.T) {
 		{path: "nope", ignore: ignoreNone, count: 0, err: " "},
 	}
 
+	e := &env.Env{Directory: filepath.Join("_testdata", "project")}
 	for _, testcase := range testcases {
-		assets, err := loadAssetsFromDirectory(root, testcase.path, testcase.ignore)
+		assets, err := loadAssetsFromDirectory(e, testcase.path, testcase.ignore)
 		if testcase.err == "" {
 			assert.Nil(t, err)
 			assert.Equal(t, testcase.count, len(assets))
@@ -133,7 +133,6 @@ func TestReadAsset(t *testing.T) {
 		// `app_alternate.json` has the same content but different whitespace. Since we normalise JSON before persisting, it has the same checksum.
 		{input: filepath.Join("assets", "app_alternate.json"), expected: Asset{Key: "assets/app_alternate.json", Value: "{\"testing\":\"data\"}", Checksum: "31409bedd9f5852166c0a4a9b874f1a7"}},
 		{input: filepath.Join("assets", "template.liquid"), expected: Asset{Key: "assets/template.liquid", Value: "{% comment %}\n  The contents\n{% endcomment %}\n", Checksum: "8bed50f07f1e8d52b07300e983c21a86"}},
-
 	}
 
 	for _, testcase := range testcases {

--- a/src/shopify/theme_client.go
+++ b/src/shopify/theme_client.go
@@ -235,7 +235,7 @@ func (c Client) PublishTheme() error {
 // The assets returned will not have any data, only ID and filenames. This is because
 // fetching all the assets at one time is not a good idea.
 func (c Client) GetAllAssets() ([]Asset, error) {
-	resp, err := c.http.Get(c.assetPath(map[string]string{"fields": "key"}))
+	resp, err := c.http.Get(c.assetPath(map[string]string{"fields": "key,checksum"}))
 	if err != nil {
 		return []Asset{}, err
 	} else if resp.StatusCode == 404 {

--- a/src/shopify/theme_client_test.go
+++ b/src/shopify/theme_client_test.go
@@ -251,7 +251,7 @@ func TestThemeClient_GetAllAssets(t *testing.T) {
 		client, _ := NewClient(&env.Env{ThemeID: "123"})
 		client.http = m
 
-		expectation := m.On("Get", "/admin/themes/123/assets.json?fields=key")
+		expectation := m.On("Get", "/admin/themes/123/assets.json?fields=key%2Cchecksum")
 		if testcase.resperr != "" {
 			expectation.Return(nil, errors.New(testcase.resperr))
 		} else {
@@ -294,7 +294,7 @@ func TestThemeClient_GetAllAssets(t *testing.T) {
 		m := new(mocks.HttpAdapter)
 		client, _ := NewClient(&env.Env{ThemeID: "123", IgnoredFiles: testcase.ignore})
 		client.http = m
-		m.On("Get", "/admin/themes/123/assets.json?fields=key").Return(jsonResponse(testcase.input, 200), nil)
+		m.On("Get", "/admin/themes/123/assets.json?fields=key%2Cchecksum").Return(jsonResponse(testcase.input, 200), nil)
 		assets, err := client.GetAllAssets()
 		assert.Nil(t, err)
 		assert.Equal(t, testcase.expected, assets)


### PR DESCRIPTION
* Refactored to pass around Assets rather than files paths. This is to make it easier to compare checksums.
* Implemented behaviour to skip downloads where the local checksum matches the server checksum.
* Added some verbose output for easier troubleshooting to indicate skipped files.
* Updated the tests as necessary.
* Fixed an existing bug in the `compileAssetFilenames` method.
* Altered the API call to fetch checksum from server.

Pairing with @tanema, @ayronshopify and @carmelal 
### Warn Checklist
- [ ] This changes the interface and requires a Major/Minor version change.
- [x] I have :tophat:'d these changes by using the commands I changed by hand.
- [ ] I have added a dependancy to the project.
