### PR TITLE
Skip uploads if checksums match

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -47,7 +47,9 @@ func download(ctx *cmdutil.Ctx) error {
 
 			localAsset, _ := shopify.ReadAsset(ctx.Env, requestAsset.Key)
 			if localAsset.Checksum == requestAsset.Checksum && requestAsset.Checksum != "" {
-				ctx.Log.Printf("[%s] Skipped %s (%s)", colors.Green(ctx.Env.Name), colors.Blue(requestAsset.Key), localAsset.Checksum)
+				if ctx.Flags.Verbose {
+			  	ctx.Log.Printf("[%s] Skipped %s (%s)", colors.Green(ctx.Env.Name), colors.Blue(requestAsset.Key), localAsset.Checksum)
+			  }
 			} else if asset, err := ctx.Client.GetAsset(requestAsset.Key); err != nil {
 				ctx.Err("[%s] error downloading %s: %s", colors.Green(ctx.Env.Name), colors.Blue(requestAsset.Key), err)
 			} else if err = asset.Write(ctx.Env.Directory); err != nil {

--- a/src/file/watcher.go
+++ b/src/file/watcher.go
@@ -18,6 +18,8 @@ const (
 	Update Op = iota
 	// Remove is a file op where the file is removed
 	Remove
+	// Skip is a file op where the remote file matches the local file so is not transferred
+	Skip
 	filepathSplit = " -> "
 )
 


### PR DESCRIPTION
Co-authored with @ayronshopify 

Depends on this Core change: https://github.com/Shopify/shopify/pull/251785

TODO:

- [ ] squash commits after final approval

This PR adds behaviour so that if a files local checksum matches the remote checksum, then we skip it.

The existing upload process had two variants:
- If no list of files is provided to `deploy`, it will first make a GET request to discover what files are on the server. From this it can determine if any local files should be deleted.
- If a list of files it provided to `deploy`, then it does not make the GET request. 

To compare local checksums against remote checksums, we now need to make the GET request for both these situations.

Note: There are also fixes to no longer show skipped files when in non-verbose mode.

- [x] Verify how `watch` behaves now.

### Warn Checklist
- [ ] This changes the interface and requires a Major/Minor version change.
- [x] I have :tophat:'d these changes by using the commands I changed by hand.
- [ ] ~I have added a dependancy to the project.~ No new dependencies
