### PR TITLE
feat: publish a docker image each time a GitHub release is generated 

### DIFF
--- a/.github/workflows/dockerfile-release.yml
+++ b/.github/workflows/dockerfile-release.yml
@@ -15,4 +15,5 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           repository: thisislawatts/themekit
+          tags: latest
           tag_with_ref: true

--- a/.github/workflows/dockerfile-release.yml
+++ b/.github/workflows/dockerfile-release.yml
@@ -1,0 +1,18 @@
+name: Publish Docker image
+on:
+  release:
+    types: [published]
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Push to Docker Hub
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: thisislawatts/themekit
+          tag_with_ref: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM golang:alpine AS builder
+
+# Install git.
+# Git is required for fetching the dependencies.
+# Make is required for installing.
+RUN apk update && apk add --no-cache git make
+
+WORKDIR $GOPATH/src/github.com/Shopify/themekit
+COPY . .
+
+# Build the binary.
+RUN make
+
+FROM scratch
+
+# Copy our static executable.
+COPY --from=builder /go/bin/theme /go/bin/theme
+
+# Run the binary.
+ENTRYPOINT ["/go/bin/theme"]


### PR DESCRIPTION

### Warn Checklist
- [ ] This changes the interface and requires a Major/Minor version change.
- [ ] I have :tophat:'d these changes by using the commands I changed by hand.
- [X] I have added a dependancy to the project.

I am looking to use themekit as part of our CI/CD pipeline. Rather than introducing Python as a requirement for the build process it would be great if there was a Docker image I could pull down which already has `themekit` available.

Adding more manual processes to a Release process if no way to make friends, so this PR introduces a GitHub workflow to automatically publish to DockerHub each time a Release is created on GitHub.

All that you need to do is add DockerHub username and password to the GitHub repository.

```
docker run --rm thisislawatts/themekit version
```
Note: The above command will output 1.0.6 as [I incremented the version in my forked repo during testing](https://github.com/thisislawatts/themekit/commit/72cf456305d2c4cf92f46b6c5f2b7ca8aeaba5af)

Look forward to hearing your thoughts.
