### PR TITLE
fix broken link in nav

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ coverage.txt
 docs/_site/
 docs/.sass-cache/
 docs/.jekyll-metadata
+.jekyll-cache/
 
 # created when using mitm_proxy
 themekit_dump

--- a/docs/_includes/sidebar.html
+++ b/docs/_includes/sidebar.html
@@ -11,7 +11,7 @@
         <a class="docs-nav__link" href="{{ '/#get-api-access' | prepend: site.baseurl }}">Get API Access</a>
       </li>
       <li>
-        <a class="docs-nav__link" href="{{ '/#use-a-new-theme' | prepend: site.baseurl }}">Use a new theme</a>
+        <a class="docs-nav__link" href="{{ '/#create-a-new-theme' | prepend: site.baseurl }}">Create a new theme</a>
       </li>
       <li>
         <a class="docs-nav__link" href="{{ '/#configure-an-existing-theme' | prepend: site.baseurl }}">Configure an existing theme</a>

--- a/docs/index.md
+++ b/docs/index.md
@@ -93,7 +93,7 @@ You'll need to set up new Shopify API credentials to connect Theme Kit to your s
 
 You'll return to the app detail page. Your new, unique access credentials are visible in the **Admin API** section. Copy the password. You'll use it in the next step.
 
-<video src="https://screenshot.click/themekit-private-app-setup-1000p15-192kbps.mp4" style="max-width: 100%" controls="false" loop autoplay>Sorry, your browser doesn't support embedded video.</video>
+<video src="https://screenshot.click/themekit-private-app-setup-1000p15-192kbps.mp4" style="max-width: 100%" loop autoplay>Sorry, your browser doesn't support embedded video.</video>
 
 ## Create a new theme.
 


### PR DESCRIPTION
This PR updates a broken ID link in the navigation.

It also adds `.jekyll-cache` to gitignore for cleaner commit workflow.