### PR TITLE
Adding Retries and improved throttling to HTTP requests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/vektra/mockery v1.1.2 // indirect
 	golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3 // indirect
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
+	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e
 	gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -84,6 +84,8 @@ golang.org/x/sys v0.0.0-20190318195719-6c81ef8f67ca/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e h1:EHBhcS0mlXEAVwNyO2dLfjToGsyY4j24pTs2ScHnX7s=
+golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190319232107-3f1ed9edd1b4 h1:4oAPsdy/MJIeaCzEMEhYwYBU/gHkXH52Xa4M+0GBHfA=
 golang.org/x/tools v0.0.0-20190319232107-3f1ed9edd1b4/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=

--- a/src/httpify/client_test.go
+++ b/src/httpify/client_test.go
@@ -102,10 +102,12 @@ func TestClient_do(t *testing.T) {
 	var mut sync.Mutex
 	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		mut.Lock()
-		defer mut.Unlock()
 		if request == 0 {
 			request++
-			time.Sleep(3 * time.Second)
+			mut.Unlock()
+			time.Sleep(time.Second)
+		} else {
+			mut.Unlock()
 		}
 	}))
 

--- a/src/ratelimiter/rate_limiter_test.go
+++ b/src/ratelimiter/rate_limiter_test.go
@@ -21,6 +21,6 @@ func TestRateLimiterResetAfter(t *testing.T) {
 	assert.Equal(t, limiter.rate.Limit(), rate.Limit(1))
 	limiter.ResetAfter(time.Millisecond)
 	assert.Equal(t, limiter.rate.Limit(), rate.Limit(0))
-	time.Sleep(time.Millisecond)
+	time.Sleep(2 * time.Millisecond)
 	assert.Equal(t, limiter.rate.Limit(), rate.Limit(1))
 }

--- a/src/shopify/theme_client.go
+++ b/src/shopify/theme_client.go
@@ -10,7 +10,6 @@ import (
 	"net/url"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/Shopify/themekit/src/env"
 	"github.com/Shopify/themekit/src/file"
@@ -38,8 +37,6 @@ var (
 	ErrMissingAssetName = errors.New("asset has no name so could not be processes")
 	// ErrThemeNameRequired is returned when trying to create a theme with a blank name
 	ErrThemeNameRequired = errors.New("theme name is required to create a theme")
-
-	shopifyAPILimit = time.Second / 2 // 2 calls per second
 )
 
 // Theme represents a shopify theme.
@@ -111,7 +108,6 @@ func NewClient(e *env.Env) (Client, error) {
 		Password: e.Password,
 		Proxy:    e.Proxy,
 		Timeout:  e.Timeout,
-		APILimit: shopifyAPILimit,
 	})
 	if err != nil {
 		return Client{}, err


### PR DESCRIPTION
fixes #715
fixes #665

### What is this PR solving
This will solve a few errors with asset requests, more specifically timeouts but also hopefully speed up requests during actions like `deploy` especially for plus merchants. 

#### Before
Themekit was throttled directly to 2 requests per second to just try to ensure that a 429 was never received. 

### Now
I have added strategy to throtting.
- Changes to the rate limiter
  - made it nicer to specify requests per second (for myself)
  - using a (x)-std lib library for throttling instead to get the bonus of bursts
  - added `ResetAfter` to halt everything until a future time.
- Changes to the http client
  - rate limiter is not limiting to 4 requests per second (the plus limit)
  - if we get a 429 we record the time that we should resume and the request is set to retry
  - all requests are held until it is that time.
  - once that time has passed, we resume our normal throttling
  - if a timeout is received, it will be retried
  - all timeout requests are retried at a maximum of 5 times
  - if a timeout is received after 5 retries, the user is notified that there may be an issue with their connection.

#### Performance notes
I have noticed that this works noticably faster now but also has the side effect of being really fast at the begining and slower at the end, which might make it feel slower. 

This has hopefully eliminated timeouts,

### Warn Checklist
- [ ] This changes the interface and requires a Major/Minor version change.
- [x] I have :tophat:'d these changes by using the commands I changed by hand.
- [x] I have added a dependancy to the project.
