### PR TITLE
add --notify-upload flag to notify when a file has finished uploading (fixes #749)

### DIFF
--- a/cmd/theme.go
+++ b/cmd/theme.go
@@ -91,6 +91,7 @@ func init() {
 	ThemeCmd.PersistentFlags().BoolVar(&flags.AllowLive, "allow-live", false, "Will allow themekit to make changes to the live theme on the store.")
 
 	watchCmd.Flags().StringVarP(&flags.NotifyFile, "notify", "n", "", "file to touch when workers have gone idle")
+	watchCmd.Flags().StringVarP(&flags.NotifyUploadFile, "notify-upload", "u", "", "file to touch when files have finished uploading")
 	watchCmd.Flags().BoolVarP(&flags.AllEnvs, "allenvs", "a", false, "run command with all environments")
 	removeCmd.Flags().BoolVarP(&flags.AllEnvs, "allenvs", "a", false, "run command with all environments")
 	openCmd.Flags().BoolVarP(&flags.AllEnvs, "allenvs", "a", false, "run command with all environments")

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -117,6 +118,10 @@ func perform(ctx *cmdutil.Ctx, path string, op file.Op) {
 			ctx.Err("[%s] (%s) %s", colors.Green(ctx.Env.Name), colors.Blue(asset.Key), err)
 		} else if ctx.Flags.Verbose {
 			ctx.Log.Printf("[%s] Updated %s", colors.Green(ctx.Env.Name), colors.Blue(asset.Key))
+			if ctx.Flags.NotifyUploadFile != "" {
+				os.Create(ctx.Env.NotifyUpload)
+				os.Chtimes(ctx.Env.NotifyUpload, time.Now(), time.Now())
+			}
 		}
 	}
 }

--- a/src/cmdutil/util.go
+++ b/src/cmdutil/util.go
@@ -44,6 +44,7 @@ type Flags struct {
 	Ignores               []string
 	DisableIgnore         bool
 	NotifyFile            string
+	NotifyUploadFile      string
 	AllEnvs               bool
 	Version               string
 	Prefix                string
@@ -228,13 +229,14 @@ func generateContexts(newClient clientFact, progress *mpb.Progress, flags Flags,
 
 func getFlagEnv(flags Flags) env.Env {
 	flagEnv := env.Env{
-		Directory: flags.Directory,
-		Password:  flags.Password,
-		ThemeID:   flags.ThemeID,
-		Domain:    flags.Domain,
-		Proxy:     flags.Proxy,
-		Timeout:   flags.Timeout,
-		Notify:    flags.NotifyFile,
+		Directory:    flags.Directory,
+		Password:     flags.Password,
+		ThemeID:      flags.ThemeID,
+		Domain:       flags.Domain,
+		Proxy:        flags.Proxy,
+		Timeout:      flags.Timeout,
+		Notify:       flags.NotifyFile,
+		NotifyUpload: flags.NotifyUploadFile,
 	}
 
 	if !flags.DisableIgnore {

--- a/src/env/env.go
+++ b/src/env/env.go
@@ -24,6 +24,7 @@ type Env struct {
 	Timeout      time.Duration `yaml:"timeout,omitempty" json:"timeout,omitempty" env:"THEMEKIT_TIMEOUT"`
 	ReadOnly     bool          `yaml:"readonly,omitempty" json:"readonly,omitempty" env:"-"`
 	Notify       string        `yaml:"notify,omitempty" json:"notify,omitempty" env:"THEMEKIT_NOTIFY"`
+	NotifyUpload string        `yaml:"notify_upload,omitempty" json:"notify_upload,omitempty" env:"THEMEKIT_NOTIFY_UPLOAD"`
 }
 
 //Default is the default values for a environment


### PR DESCRIPTION
This fixes #749.

The `--notify` command currently touches a file when all workers are idle. This is not useful for *livereload* purposes.

I added a `--notify-upload` command that will touch a file after a file has finished uploading.

You might want to just completely replace the `--notify` flag with this behavior, but I wasn't sure if you implemented it like that for some particular use case I'm not aware of.

This needs automated tests (I'm already using this in my local project and it works great though) and the new command would need to be added to the docs.

In the future, a really nice addition would be to actually be able to be notified about which files where just uploaded. This could be done via a POST request to a webhook specified by the user.

Disclaimer: this is my first time writing any *go* code. I just quickly added these changes because I started developing a Shopify theme and wanted this change, so I wrote this for myself and then figured I could just submit a PR and let you guys decide if you want to merge it or take it as inspiration to implement my changes in a better way.