### PR TITLE
Automatically allowing live on open and download

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -28,6 +28,8 @@ var downloadCmd = &cobra.Command{
  For more documentation please see http://shopify.github.io/themekit/commands/#download
  `,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// download should not care about the live theme
+		flags.AllowLive = true
 		return cmdutil.ForEachClient(flags, args, download)
 	},
 }

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -19,6 +19,8 @@ var openCmd = &cobra.Command{
 	Long: `Open will open the preview page in your browser as well as print out
 url for your reference`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// open should not care about the live theme
+		flags.AllowLive = true
 		return cmdutil.ForSingleClient(flags, args, func(ctx *cmdutil.Ctx) error {
 			return preview(ctx, open.Run, open.RunWith)
 		})

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -61,6 +61,7 @@ var watchCmd = &cobra.Command{
 }
 
 func watch(ctx *cmdutil.Ctx, events chan file.Event, sig chan os.Signal, notifier notifyAdapter) error {
+	// watch should output every action that it is taking and not use a progress bar
 	ctx.Flags.Verbose = true
 	ctx.Log.SetFlags(log.Ltime)
 

--- a/src/env/env.go
+++ b/src/env/env.go
@@ -53,6 +53,8 @@ func (env *Env) validate() error {
 
 	if env.ThemeID == "" {
 		errors = append(errors, "missing theme_id")
+	} else if env.ThemeID == "live" {
+		errors = append(errors, "'live' is no longer supported for theme_id. Please use an ID instead")
 	} else if _, err := strconv.ParseInt(env.ThemeID, 10, 64); err != nil {
 		errors = append(errors, "invalid theme_id")
 	}

--- a/src/env/env_test.go
+++ b/src/env/env_test.go
@@ -45,7 +45,7 @@ func TestEnv_Validate(t *testing.T) {
 		notwindows bool
 	}{
 		{env: Env{Password: "file", ThemeID: "123", Domain: "test.myshopify.com"}},
-		{env: Env{Password: "file", ThemeID: "live", Domain: "test.myshopify.com"}, err: "invalid theme_id"},
+		{env: Env{Password: "file", ThemeID: "live", Domain: "test.myshopify.com"}, err: "invalid environment []: ('live' is no longer supported for theme_id. Please use an ID instead)"},
 		{env: Env{ThemeID: "123", Domain: "test.myshopify.com"}, err: "missing password"},
 		{env: Env{Password: "test", ThemeID: "123", Domain: "test.nope.com"}, err: "invalid store domain"},
 		{env: Env{Password: "test", ThemeID: "123"}, err: "missing store domain"},


### PR DESCRIPTION
We got some feedback from beta testing that the `--allow-live` flag is not really needed on the open and download commands so this PR automatically adds the flag to those commands so that they are able to do these actions.

#### Addition
It also occurred to me that it would make things nicer if we added output about the `live` config from the past, so I added a specific error for a live configuration.

### Warn Checklist
- [ ] This changes the interface and requires a Major/Minor version change.
- [x] I have :tophat:'d these changes by using the commands I changed by hand.
- [ ] I have added a dependancy to the project.
