### PR TITLE
Patch for the new command

### DIFF
--- a/cmd/new.go
+++ b/cmd/new.go
@@ -22,7 +22,7 @@ var newCmd = &cobra.Command{
   For more documentation please see http://shopify.github.io/themekit/commands/#new
   `,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		// This is a hack to get around theme ID validation for the list operation which doesnt need it
+		// This is a hack to get around theme ID validation for the list operation which doesn't need it
 		flags.ThemeID = "1337"
 		return cmdutil.ForDefaultClient(flags, args, func(ctx *cmdutil.Ctx) error {
 			return newTheme(ctx, static.Unbundle)

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -22,6 +22,8 @@ var newCmd = &cobra.Command{
   For more documentation please see http://shopify.github.io/themekit/commands/#new
   `,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// This is a hack to get around theme ID validation for the list operation which doesnt need it
+		flags.ThemeID = "1337"
 		return cmdutil.ForDefaultClient(flags, args, func(ctx *cmdutil.Ctx) error {
 			return newTheme(ctx, static.Unbundle)
 		})

--- a/src/env/conf.go
+++ b/src/env/conf.go
@@ -106,10 +106,7 @@ func (c *Conf) Set(name string, initial Env, overrides ...Env) (*Env, error) {
 	}
 	var err error
 	c.Envs[name], err = newEnv(name, initial, append([]Env{c.osEnv}, overrides...)...)
-	if err != nil {
-		return nil, err
-	}
-	return c.Envs[name], c.Envs[name].validate()
+	return c.Envs[name], err
 }
 
 // Get will check if an environment exists and then return it. If the environment


### PR DESCRIPTION
fixes #766 

This will fix the new command requiring a theme_id.

It also just cleans up a small bit of code that was repeated in conf while I was looking how to make these patches more official. I might be able to make these patches more official in the future.

### Warn Checklist
- [ ] This changes the interface and requires a Major/Minor version change.
- [x] I have :tophat:'d these changes by using the commands I changed by hand.
- [ ] I have added a dependancy to the project.
- [x] I have considered any potential impact on [node-themekit](https://github.com/Shopify/node-themekit)