### PR TITLE
Prepare Chocolatey v1.1.1 release

### DIFF
--- a/choco/themekit.nuspec
+++ b/choco/themekit.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>themekit</id>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
     <packageSourceUrl>https://github.com/Shopify/themekit/blob/master/choco</packageSourceUrl>
     <owners>Shopify</owners>
     <title>Shopify Themekit</title>

--- a/choco/tools/chocolateyinstall.ps1
+++ b/choco/tools/chocolateyinstall.ps1
@@ -2,11 +2,11 @@
 $toolsDir       = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $packageName    = $env:ChocolateyPackageName
 $file           = "$($toolsDir)\theme.exe"
-$version        = "v1.0.2"
+$version        = "v1.1.1"
 $url            = "https://shopify-themekit.s3.amazonaws.com/$($version)/windows-386/theme.exe"
 $url64          = "https://shopify-themekit.s3.amazonaws.com/$($version)/windows-amd64/theme.exe"
-$checksum       = '16e1073b67419268430110b3775c0463'
-$checksum64     = 'cb4e86ee372916f8247974a6012a3896'
+$checksum       = 'cee0ece1e248ce7e9d4f340045dcdbb3'
+$checksum64     = '3a1fb85c06922a842d6cec841c302e3a'
 $validExitCodes = @(0)
 
 Get-ChocolateyWebFile `


### PR DESCRIPTION
We already released v1.1.1 but not yet for Chocolately.

### Warn Checklist
- [ ] This changes the interface and requires a Major/Minor version change.
- [ ] I have :tophat:'d these changes by using the commands I changed by hand.
- [ ] I have added a dependancy to the project.
- [ ] I have considered any potential impact on [node-themekit](https://github.com/Shopify/node-themekit)
