### PR TITLE
Update Arch Linux notes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,3 @@ If troubleshooting an issue for a partner, we can ask that they provide the `the
 - Update `themekit.rb` formula for homebrew on https://github.com/Shopify/homebrew-shopify
   - run `make sha` to generate the SHA256 for the darwin build
   - update the link, sha and version in the homebrew formula
-- Notify the maintainer of the AUR themekit package https://aur.archlinux.org/packages/shopify-themekit-bin
-  of an update so they can release a new version.
-

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,9 +42,14 @@ download and install the latest Theme Kit for you.
 curl -s https://shopify.github.io/themekit/scripts/install.py | sudo python
 ```
 
-### Arch installation
+### Community Packages
 
-There is a package available for install on the [AUR](https://aur.archlinux.org/packages/shopify-themekit-bin)
+Theme Kit is available through other package manager distributions, but as these are not
+maintained by Shopify, care should be taken before using:
+
+* [AUR](https://aur.archlinux.org/packages/shopify-themekit-bin)
+
+These packages may not contain the latest Theme Kit release, but running `theme update` will auto-update to the latest.
 
 ### Manual Installation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,7 +47,7 @@ curl -s https://shopify.github.io/themekit/scripts/install.py | sudo python
 Theme Kit is available through other package manager distributions, but as these are not
 maintained by Shopify, care should be taken before using:
 
-* [AUR](https://aur.archlinux.org/packages/shopify-themekit-bin)
+* [AUR](https://aur.archlinux.org/packages/shopify-themekit-bin) (@rmcfadzean)
 
 These packages may not contain the latest Theme Kit release, but running `theme update` will auto-update to the latest.
 


### PR DESCRIPTION
* Make it clear that the Theme Kit Arch Linux package is maintained by a third party, and not Shopify.
* Move the responsibility of monitoring Theme Kit for updates to the third-party package maintainer. This helps to shorten the long list of manual steps currently needed for each release. For a recent release, the maintainer made an update before we had notified, so it seems they are already monitoring it.

### Warn Checklist
- [ ] This changes the interface and requires a Major/Minor version change.
- [ ] I have :tophat:'d these changes by using the commands I changed by hand.
- [ ] I have added a dependancy to the project.
- [ ] I have considered any potential impact on [node-themekit](https://github.com/Shopify/node-themekit)
