### PR TITLE
Update documentation

### DIFF
--- a/cmd/new.go
+++ b/cmd/new.go
@@ -14,7 +14,7 @@ import (
 
 var newCmd = &cobra.Command{
 	Use:   "new",
-	Short: "New will create theme using Shopify in the same directory where it gets called from",
+	Short: "New will generate a new blank slate theme in the same directory where it gets called from and create a new theme on Shopify with those files.",
 	Long: `New will create a new theme on Shopify, generate a minimal template of
 	all the required files that a theme needs to be functional and then setup
 	your config file for working with your new theme. Note: by default the new command will generate files in

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -14,10 +14,12 @@ import (
 
 var newCmd = &cobra.Command{
 	Use:   "new",
-	Short: "New will create theme using Shopify Timber",
+	Short: "New will create theme using Shopify Timber in the same directory where it gets called from",
 	Long: `New will create a new theme on Shopify, generate a minimal template of
 	all the required files that a theme needs to be functional and then setup
-  your config file for working with your new theme.
+	your config file for working with your new theme. Note: by default the new command will generate files in
+	the same directory it's called from. Use the --dir flag to specify a custom directory where the generated files
+	should be placed.
 
   For more documentation please see http://shopify.github.io/themekit/commands/#new
   `,

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -14,7 +14,7 @@ import (
 
 var newCmd = &cobra.Command{
 	Use:   "new",
-	Short: "New will create theme using Shopify Timber in the same directory where it gets called from",
+	Short: "New will create theme using Shopify in the same directory where it gets called from",
 	Long: `New will create a new theme on Shopify, generate a minimal template of
 	all the required files that a theme needs to be functional and then setup
 	your config file for working with your new theme. Note: by default the new command will generate files in

--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -115,7 +115,7 @@ development:
 
 If you are starting a new theme and want to have some sane defaults, you can use
 the new command. The command will
-- Create a new theme on shopify with the provided name.
+- Create a new theme on shopify with the provided name in the current directory you are in.
 - Initialize your configuration with your credentials and your new theme id.
 - Generate and upload some default templates to make your theme valid.
 
@@ -132,6 +132,9 @@ theme new --password=[your-api-password] --store=[your-store.myshopify.com] --na
 |`-p`|`--password`| Password for access to your Shopify account.
 |`-s`|`--store   `| Your store's domain for changes to take effect
 |`-n`|`--name    `| The name of your new theme.
+
+|**Optional Flags**||
+|`--dir`| Directory to place all of the files for the new theme in. **Note:** Directory must exist beforehand.
 
 ## Open
 Open will open the preview page for your theme in your browser as well as print


### PR DESCRIPTION
I've updated the documentation for the `new` command to include a table with optional flags and indicate that by default the command will use the current directory and not create a new one.

Fixes #753, #795 

### Warn Checklist
- [ ] This changes the interface and requires a Major/Minor version change.
- [ ] I have :tophat:'d these changes by using the commands I changed by hand.
- [ ] I have added a dependancy to the project.
- [x] I have considered any potential impact on [node-themekit](https://github.com/Shopify/node-themekit)
