### PR TITLE
Fixing hanging uploads

### DIFF
--- a/src/httpify/client_test.go
+++ b/src/httpify/client_test.go
@@ -105,7 +105,7 @@ func TestClient_do(t *testing.T) {
 		if request == 0 {
 			request++
 			mut.Unlock()
-			time.Sleep(time.Second)
+			time.Sleep(5 * time.Millisecond)
 		} else {
 			mut.Unlock()
 		}
@@ -139,7 +139,7 @@ func TestClient_do(t *testing.T) {
 	assert.Nil(t, err)
 
 	_, err = client.do("POST", "/assets.json", body, nil)
-	assert.EqualError(t, err, "request timed out after 1 retries, there may be an issue with your connection")
+	assert.Contains(t, err.Error(), "request failed after 1 retries with err: ", server.URL)
 	server.Close()
 }
 


### PR DESCRIPTION
fixes #790 
fixes #801 
fixes #810 

Re-evaluating the retry mechanism, I realized that there was a fault in the if statements where the attempt count would only get incremented on timeouts and not for all other errors like 500s.

Here is the logic now
- if non-retryable http status (success or otherwise), return (100 =< code <= 428)
- if 499 then use retry-after header to block all requests until after the time limit then continue without incrementing attempt because this is not an error. I don't want to fail out of uploads because of 499s
- If request failed with host error, its fatal, return
- Otherwise, increment attempt and try again

### Warn Checklist
- [ ] This changes the interface and requires a Major/Minor version change.
- [x] I have :tophat:'d these changes by using the commands I changed by hand.
- [ ] I have added a dependancy to the project.
- [ ] I have considered any potential impact on [node-themekit](https://github.com/Shopify/node-themekit)
