### PR TITLE
Increase timeout of test HTTP client

### DIFF
--- a/src/httpify/client_test.go
+++ b/src/httpify/client_test.go
@@ -113,7 +113,7 @@ func TestClient_do(t *testing.T) {
 
 	client, _ = NewClient(Params{
 		Domain:  server.URL,
-		Timeout: time.Millisecond,
+		Timeout: 5 * time.Millisecond,
 	})
 	client.baseURL.Scheme = "http"
 
@@ -130,7 +130,7 @@ func TestClient_do(t *testing.T) {
 
 	client, _ = NewClient(Params{
 		Domain:  server.URL,
-		Timeout: time.Millisecond,
+		Timeout: 5 * time.Millisecond,
 	})
 	client.maxRetry = 1
 	client.baseURL.Scheme = "http"


### PR DESCRIPTION
Fixes #814 

We had some tests that intermittently failed because we were running the HTTP client with a 1ms timeout, and sometimes that wasn't enough to deal with the test requests in time.

This PR increases that timeout to 5ms, which seems to make it so the tests pass reliably.

### Warn Checklist
- [ ] This changes the interface and requires a Major/Minor version change.
- [X] I have :tophat:'d these changes by using the commands I changed by hand.
- [ ] I have added a dependancy to the project.
- [X] I have considered any potential impact on [node-themekit](https://github.com/Shopify/node-themekit)
