### PR TITLE
Action summary and return status

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,9 @@
+v1.1.3
+=====================
+- Added an error summary (#826)
+- Added error count to action summary (#826)
+- Set status error codes when errors occur for better scriptability (#826)
+
 v1.1.2 (Sep 29, 2020)
 =====================
 - Fix hanging uploads (#809)

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -48,6 +48,8 @@ var deployCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return cmdutil.ForEachClient(flags, args, deploy)
 	},
+	PostRun: func(cmd *cobra.Command, args []string) {
+	},
 }
 
 func deploy(ctx *cmdutil.Ctx) error {
@@ -59,16 +61,6 @@ func deploy(ctx *cmdutil.Ctx) error {
 	if err != nil {
 		return err
 	}
-
-	updateCount := 0
-	skipCount := 0
-	removeCount := 0
-
-	defer func() {
-		if ctx.Flags.Verbose {
-			fmt.Printf("Updated: %d, Removed: %d, No Changes: %d\n", updateCount, removeCount, skipCount)
-		}
-	}()
 
 	var deployGroup sync.WaitGroup
 	ctx.StartProgress(len(assetsActions))
@@ -82,18 +74,10 @@ func deploy(ctx *cmdutil.Ctx) error {
 			defer deployGroup.Done()
 			perform(ctx, path, op, "")
 		}(path, op)
-
-		switch op {
-		case file.Update:
-			updateCount++
-		case file.Skip:
-			skipCount++
-		case file.Remove:
-			removeCount++
-		}
 	}
 
 	deployGroup.Wait()
+
 	return nil
 }
 

--- a/cmd/theme.go
+++ b/cmd/theme.go
@@ -103,5 +103,17 @@ func init() {
 	getCmd.Flags().BoolVarP(&flags.List, "list", "l", false, "list available themes.")
 	deployCmd.Flags().BoolVarP(&flags.NoDelete, "nodelete", "n", false, "do not delete files on shopify during deploy.")
 
-	ThemeCmd.AddCommand(publishCmd, openCmd, versionCmd, newCmd, configureCmd, downloadCmd, removeCmd, updateCmd, watchCmd, getCmd, deployCmd)
+	ThemeCmd.AddCommand(
+		publishCmd,
+		openCmd,
+		versionCmd,
+		newCmd,
+		configureCmd,
+		downloadCmd,
+		removeCmd,
+		updateCmd,
+		watchCmd,
+		getCmd,
+		deployCmd,
+	)
 }

--- a/cmd/theme/main.go
+++ b/cmd/theme/main.go
@@ -27,7 +27,7 @@ func main() {
 	}
 
 	if err := cmd.ThemeCmd.Execute(); err != nil {
-		stdErr.Fatal(err)
+		stdErr.Fatal(colors.Red(err.Error()))
 	}
 
 	if memProfile := os.Getenv(memProfileVar); memProfile != "" {

--- a/src/cmdutil/summary.go
+++ b/src/cmdutil/summary.go
@@ -1,0 +1,71 @@
+package cmdutil
+
+import (
+	"fmt"
+	"strings"
+	"sync/atomic"
+
+	"github.com/Shopify/themekit/src/colors"
+	"github.com/Shopify/themekit/src/file"
+)
+
+type cmdSummary struct {
+	actions, downloaded, uploaded, skipped, removed int32
+	disabled                                        bool
+	errors                                          []string
+}
+
+func (sum *cmdSummary) completeOp(op file.Op) {
+	atomic.AddInt32(&sum.actions, 1)
+	switch op {
+	case file.Update:
+		atomic.AddInt32(&sum.uploaded, 1)
+	case file.Skip:
+		atomic.AddInt32(&sum.skipped, 1)
+	case file.Remove:
+		atomic.AddInt32(&sum.removed, 1)
+	case file.Get:
+		atomic.AddInt32(&sum.downloaded, 1)
+	}
+}
+
+func (sum *cmdSummary) disable() {
+	sum.disabled = true
+}
+
+func (sum *cmdSummary) err(errStr string) {
+	sum.errors = append(sum.errors, errStr)
+}
+
+func (sum *cmdSummary) hasErrors() bool {
+	return !sum.disabled && len(sum.errors) > 0
+}
+
+func (sum *cmdSummary) display(ctx *Ctx) {
+	if sum.disabled || sum.actions == 0 {
+		return
+	}
+	var results = []string{fmt.Sprintf("%v files", sum.actions)}
+	if sum.downloaded > 0 {
+		results = append(results, fmt.Sprintf("%v: %v", colors.Blue("Downloaded"), sum.downloaded))
+	}
+	if sum.uploaded > 0 {
+		results = append(results, fmt.Sprintf("%v: %v", colors.Green("Updated"), sum.uploaded))
+	}
+	if sum.removed > 0 {
+		results = append(results, fmt.Sprintf("%v: %v", colors.Yellow("Removed"), sum.removed))
+	}
+	if sum.skipped > 0 {
+		results = append(results, fmt.Sprintf("%v: %v", colors.Cyan("No Change"), sum.skipped))
+	}
+	if len(sum.errors) > 0 {
+		results = append(results, fmt.Sprintf("%v: %v", colors.Red("Errored"), len(sum.errors)))
+	}
+	ctx.Log.Printf("[%v] %v", colors.Green(ctx.Env.Name), strings.Join(results, ", "))
+	if len(sum.errors) > 0 {
+		ctx.ErrLog.Printf("[%s] %s", colors.Green(ctx.Env.Name), colors.Red("Errors encountered: "))
+		for _, msg := range sum.errors {
+			ctx.ErrLog.Printf("\t%v", msg)
+		}
+	}
+}

--- a/src/cmdutil/summary_test.go
+++ b/src/cmdutil/summary_test.go
@@ -1,0 +1,88 @@
+package cmdutil
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/Shopify/themekit/src/env"
+	"github.com/Shopify/themekit/src/file"
+)
+
+func TestSummaryCompleteOp(t *testing.T) {
+	summary := cmdSummary{}
+
+	summary.completeOp(file.Get)
+	assert.Equal(t, summary.downloaded, int32(1))
+
+	summary.completeOp(file.Update)
+	assert.Equal(t, summary.uploaded, int32(1))
+
+	summary.completeOp(file.Skip)
+	assert.Equal(t, summary.skipped, int32(1))
+
+	summary.completeOp(file.Remove)
+	assert.Equal(t, summary.removed, int32(1))
+
+	assert.Equal(t, summary.actions, int32(4))
+}
+
+func TestSummaryDisable(t *testing.T) {
+	summary := cmdSummary{}
+	assert.False(t, summary.disabled)
+	summary.disable()
+	assert.True(t, summary.disabled)
+}
+
+func TestSummaryErr(t *testing.T) {
+	summary := cmdSummary{}
+	assert.Equal(t, summary.errors, []string(nil))
+	summary.err("no good")
+	assert.Equal(t, summary.errors, []string{"no good"})
+}
+
+func TestSummaryHasErrors(t *testing.T) {
+	summary := cmdSummary{}
+	assert.False(t, summary.hasErrors())
+	summary.err("no good")
+	assert.True(t, summary.hasErrors())
+	summary.disable()
+	assert.False(t, summary.hasErrors())
+}
+
+func TestSummaryDisplay(t *testing.T) {
+	out, err := rundisplay(cmdSummary{actions: 23})
+	assert.Equal(t, out, fmt.Sprintf("[sum] 23 files\n"))
+	assert.Equal(t, err, "")
+
+	out, err = rundisplay(cmdSummary{actions: 23, downloaded: 21})
+	assert.Equal(t, out, fmt.Sprintf("[sum] 23 files, Downloaded: 21\n"))
+	assert.Equal(t, err, "")
+
+	out, err = rundisplay(cmdSummary{actions: 23, uploaded: 21})
+	assert.Equal(t, out, fmt.Sprintf("[sum] 23 files, Updated: 21\n"))
+	assert.Equal(t, err, "")
+
+	out, err = rundisplay(cmdSummary{actions: 23, removed: 42})
+	assert.Equal(t, out, fmt.Sprintf("[sum] 23 files, Removed: 42\n"))
+	assert.Equal(t, err, "")
+
+	out, err = rundisplay(cmdSummary{actions: 23, skipped: 11})
+	assert.Equal(t, out, fmt.Sprintf("[sum] 23 files, No Change: 11\n"))
+	assert.Equal(t, err, "")
+
+	out, err = rundisplay(cmdSummary{actions: 23, errors: []string{"one", "two", "three"}})
+	assert.Equal(t, out, fmt.Sprintf("[sum] 23 files, Errored: 3\n"))
+	assert.Equal(t, err, "[sum] Errors encountered: \n\tone\n\ttwo\n\tthree\n")
+}
+
+func rundisplay(summary cmdSummary) (stdout, stderr string) {
+	stdOut := bytes.NewBufferString("")
+	stdErr := bytes.NewBufferString("")
+	ctx := &Ctx{Env: &env.Env{Name: "sum"}, Log: log.New(stdOut, "", 0), ErrLog: log.New(stdErr, "", 0)}
+	summary.display(ctx)
+	return stdOut.String(), stdErr.String()
+}

--- a/src/colors/colors.go
+++ b/src/colors/colors.go
@@ -20,6 +20,6 @@ var (
 	ColorStdOut = log.New(colorable.NewColorableStdout(), "", 0)
 	// ColorStdErr is a wrapped std err that allows colors
 	ColorStdErr = log.New(colorable.NewColorableStderr(), "", 0)
-	// BrightBlack is the color Black
-	BrightBlack = color.New(color.FgBlack).SprintFunc()
+	// Cyan is the color cyan
+	Cyan = color.New(color.FgCyan).SprintFunc()
 )

--- a/src/file/watcher.go
+++ b/src/file/watcher.go
@@ -23,6 +23,8 @@ const (
 	Remove
 	// Skip is a file op where the remote file matches the local file so is not transferred
 	Skip
+	// Get is when a file should be re-fetched, used in download operations
+	Get
 	filepathSplit = " -> "
 )
 


### PR DESCRIPTION
fixes #823 
fixes #822 
fixes #738 

This PR is an effort to collect runtime file operations data and present them at the end of the runtime. This will have multiple effects
- Changed skipped color to cyan instead
- Showing the summary (download, upload, deleted, skipped, errors) of changes for `deploy` `remove` `download` `get` `new` with a consistent theme between all.
- Showing a count of errors
- Showing an output of the errors that were encountered
- Collecting error data to return status (still need to do) Currently themekit only sets error status if an error is returned however we need a way to return a general error if any were encountered during runtime
- Set error status when errors happened during file changes
- Make all fatal errors red.

![image](https://user-images.githubusercontent.com/463193/96017129-9c0bfc80-0e17-11eb-9e2a-3e9dac299d94.png)

Updated Screenshot:

![image](https://user-images.githubusercontent.com/463193/96266359-8ff97980-0f94-11eb-98f3-de9ce8548e24.png)

### TODO
- [x] Testing
- [x] Opting-out for commands like `watch` other non-file operations like `open` are not shown since no actions take place.
- [x] Set status

### Warn Checklist
- [ ] This changes the interface and requires a Major/Minor version change.
- [x] I have :tophat:'d these changes by using the commands I changed by hand.
- [ ] I have added a dependancy to the project.
- [x] I have considered any potential impact on [node-themekit](https://github.com/Shopify/node-themekit)
