### PR TITLE
Hide PB on open

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@ v1.1.3
 - Set status error codes when errors occur for better scriptability (#826)
 - Added --live flag to get, download, configure to automatically set
 configuration to the published theme
+- Added --hidepb flag to hide preview bar (#829)
 
 v1.1.2 (Sep 29, 2020)
 =====================

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -29,7 +29,7 @@ url for your reference`,
 
 func preview(ctx *cmdutil.Ctx, run runFunc, runWith runWithFunc) error {
 	url := fmt.Sprintf("https://%s?preview_theme_id=%s", ctx.Env.Domain, ctx.Env.ThemeID)
-	if ctx.Flags.HidePB {
+	if ctx.Flags.HidePreviewBar {
 		url += "&pb=0"
 	}
 	if ctx.Flags.Edit {

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -29,6 +29,9 @@ url for your reference`,
 
 func preview(ctx *cmdutil.Ctx, run runFunc, runWith runWithFunc) error {
 	url := fmt.Sprintf("https://%s?preview_theme_id=%s", ctx.Env.Domain, ctx.Env.ThemeID)
+	if ctx.Flags.HidePB {
+		url += "&pb=0"
+	}
 	if ctx.Flags.Edit {
 		url = fmt.Sprintf("https://%s/admin/themes/%s/editor", ctx.Env.Domain, ctx.Env.ThemeID)
 	}

--- a/cmd/open_test.go
+++ b/cmd/open_test.go
@@ -22,6 +22,15 @@ func TestOpen(t *testing.T) {
 	ctx, _, _, _, _ = createTestCtx()
 	ctx.Env.Domain = "my.test.domain"
 	ctx.Env.ThemeID = "123"
+	ctx.Flags.HidePB = true
+	assert.Nil(t, preview(ctx, func(path string) error {
+		assert.Equal(t, path, "https://my.test.domain?preview_theme_id=123&pb=0")
+		return nil
+	}, rw))
+
+	ctx, _, _, _, _ = createTestCtx()
+	ctx.Env.Domain = "my.test.domain"
+	ctx.Env.ThemeID = "123"
 	ctx.Flags.Edit = true
 	assert.Nil(t, preview(ctx, func(path string) error {
 		assert.Equal(t, path, "https://my.test.domain/admin/themes/123/editor")

--- a/cmd/open_test.go
+++ b/cmd/open_test.go
@@ -22,7 +22,7 @@ func TestOpen(t *testing.T) {
 	ctx, _, _, _, _ = createTestCtx()
 	ctx.Env.Domain = "my.test.domain"
 	ctx.Env.ThemeID = "123"
-	ctx.Flags.HidePB = true
+	ctx.Flags.HidePreviewBar = true
 	assert.Nil(t, preview(ctx, func(path string) error {
 		assert.Equal(t, path, "https://my.test.domain?preview_theme_id=123&pb=0")
 		return nil

--- a/cmd/theme.go
+++ b/cmd/theme.go
@@ -102,6 +102,7 @@ func init() {
 	openCmd.Flags().StringVarP(&flags.With, "browser", "b", "", "name of the browser to open the url. the name should match the name of browser on your system.")
 	getCmd.Flags().BoolVarP(&flags.List, "list", "l", false, "list available themes.")
 	deployCmd.Flags().BoolVarP(&flags.NoDelete, "nodelete", "n", false, "do not delete files on shopify during deploy.")
+	openCmd.Flags().BoolVar(&flags.HidePB, "hidepb", false, "run command with all environments")
 
 	getCmd.Flags().BoolVar(&flags.Live, "live", false, "will allow themekit to autofill the theme ID as the currently published theme ID")
 	downloadCmd.Flags().BoolVar(&flags.Live, "live", false, "will allow themekit to autofill the theme ID as the currently published theme ID")

--- a/cmd/theme.go
+++ b/cmd/theme.go
@@ -102,7 +102,7 @@ func init() {
 	openCmd.Flags().StringVarP(&flags.With, "browser", "b", "", "name of the browser to open the url. the name should match the name of browser on your system.")
 	getCmd.Flags().BoolVarP(&flags.List, "list", "l", false, "list available themes.")
 	deployCmd.Flags().BoolVarP(&flags.NoDelete, "nodelete", "n", false, "do not delete files on shopify during deploy.")
-	openCmd.Flags().BoolVar(&flags.HidePB, "hidepb", false, "run command with all environments")
+	openCmd.Flags().BoolVar(&flags.HidePreviewBar, "hidepb", false, "run command with all environments")
 
 	getCmd.Flags().BoolVar(&flags.Live, "live", false, "will allow themekit to autofill the theme ID as the currently published theme ID")
 	downloadCmd.Flags().BoolVar(&flags.Live, "live", false, "will allow themekit to autofill the theme ID as the currently published theme ID")

--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -157,6 +157,7 @@ theme open --env=production # will open http://your-store.myshopify.com?preview_
 |`-a`|`--allenvs`| run command with all environments
 |`-b`|`--browser`| name of the browser to open the url, matching the name of browser on your system.
 |`-E`|`--edit   `| open the web editor for the theme.
+|    |`--hidepb `| hide preview bar when opening the the preview page
 
 ## Remove
 Remove will delete theme files both locally and on Shopify. Unlike the other file

--- a/src/cmdutil/util.go
+++ b/src/cmdutil/util.go
@@ -56,6 +56,7 @@ type Flags struct {
 	NoDelete              bool
 	AllowLive             bool
 	Live                  bool
+	HidePB                bool
 }
 
 // Ctx is a specific context that a command will run in

--- a/src/cmdutil/util.go
+++ b/src/cmdutil/util.go
@@ -56,7 +56,7 @@ type Flags struct {
 	NoDelete              bool
 	AllowLive             bool
 	Live                  bool
-	HidePB                bool
+	HidePreviewBar        bool
 }
 
 // Ctx is a specific context that a command will run in


### PR DESCRIPTION
fixes #820 

Paired with @carmelal 

Adds `--hidepb` to `theme open` to automatically hide the preview bar.

### Warn Checklist
- [ ] This changes the interface and requires a Major/Minor version change.
- [x] I have :tophat:'d these changes by using the commands I changed by hand.
- [ ] I have added a dependancy to the project.
- [x] I have considered any potential impact on [node-themekit](https://github.com/Shopify/node-themekit)
