### PR TITLE
Add Linux permissions step

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -67,6 +67,7 @@ These packages may not contain the latest Theme Kit release, but running `theme 
 
 - Download the Theme Kit binary that works for your system.
 - Compare checksums of the binary by running `md5 theme`
+- Set execute permissions with `chmod +x theme`
 - Put the binary on your path. We recommend somewhere like `/usr/local/bin`
 - Ensure that it works as expected by running `theme version`
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,7 +67,7 @@ These packages may not contain the latest Theme Kit release, but running `theme 
 
 - Download the Theme Kit binary that works for your system.
 - Compare checksums of the binary by running `md5 theme`
-- Set execute permissions with `chmod +x theme`
+- Set execute permissions with `chmod +x theme` (you may need to prefix with `sudo`)
 - Put the binary on your path. We recommend somewhere like `/usr/local/bin`
 - Ensure that it works as expected by running `theme version`
 


### PR DESCRIPTION
We set execute permission in the Python setup script but it's currently missing from the manual steps.