### PR TITLE
Adding more feedback while unmarshalling responses

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@ configuration to the published theme
 - Added --hidepb flag to hide preview bar (#829)
 - Improved request throttling and retrying, to eliminate ABS interactions and
 hanging operations (#839)
+- Adding more feedback when having issues unmarshalling responses (#840)
 
 v1.1.2 (Sep 29, 2020)
 =====================

--- a/src/shopify/theme_client.go
+++ b/src/shopify/theme_client.go
@@ -370,7 +370,7 @@ func unmarshalResponse(resp *http.Response, data interface{}) error {
 	}
 	var re reqErr
 	mainErr := json.Unmarshal(reqBody, data) // check if we can unmarshal into the expected returned data
-	basicErr := json.Unmarshal(reqBody, &re) // if not returned data, check if we can get errors from the body
+	basicErr := json.Unmarshal(reqBody, &re) // if no returned data, check if we can get errors from the body
 	if mainErr != nil && basicErr != nil {
 		errStr := "could not unmarshal JSON from response body on a response with HTTP status %v. This usually means themekit received an html error page."
 		tmpFile, err := ioutil.TempFile(os.TempDir(), "themekit-response-*.txt")

--- a/src/shopify/theme_client.go
+++ b/src/shopify/theme_client.go
@@ -372,7 +372,7 @@ func unmarshalResponse(resp *http.Response, data interface{}) error {
 	mainErr := json.Unmarshal(reqBody, data) // check if we can unmarshal into the expected returned data
 	basicErr := json.Unmarshal(reqBody, &re) // if no returned data, check if we can get errors from the body
 	if mainErr != nil && basicErr != nil {
-		errStr := "could not unmarshal JSON from response body on a response with HTTP status %v. This usually means themekit received an html error page."
+		errStr := "could not unmarshal JSON from response body on a response with HTTP status %v. This usually means Theme Kit received an HTML error page."
 		tmpFile, err := ioutil.TempFile(os.TempDir(), "themekit-response-*.txt")
 		if err == nil {
 			tmpFile.Write([]byte(reqBody))

--- a/src/shopify/theme_client.go
+++ b/src/shopify/theme_client.go
@@ -377,7 +377,7 @@ func unmarshalResponse(resp *http.Response, data interface{}) error {
 		if err == nil {
 			tmpFile.Write([]byte(reqBody))
 			tmpFile.Close()
-			errStr += " Please find the full response at %v and include it with your ticket on github."
+			errStr += " Please find the full response at %v and include it with your ticket on GitHub."
 			return fmt.Errorf(errStr, resp.StatusCode, tmpFile.Name())
 		}
 		return fmt.Errorf(errStr, resp.StatusCode)

--- a/src/shopify/theme_client.go
+++ b/src/shopify/theme_client.go
@@ -372,12 +372,13 @@ func unmarshalResponse(resp *http.Response, data interface{}) error {
 	mainErr := json.Unmarshal(reqBody, data) // check if we can unmarshal into the expected returned data
 	basicErr := json.Unmarshal(reqBody, &re) // if not returned data, check if we can get errors from the body
 	if mainErr != nil && basicErr != nil {
-		errStr := "could not unmarshal JSON from response body on a response with HTTP status %v. This usually means themekit received an html error page"
+		errStr := "could not unmarshal JSON from response body on a response with HTTP status %v. This usually means themekit received an html error page."
 		tmpFile, err := ioutil.TempFile(os.TempDir(), "themekit-response-*.txt")
 		if err == nil {
 			tmpFile.Write([]byte(reqBody))
 			tmpFile.Close()
-			return fmt.Errorf(errStr+" %v", resp.StatusCode, tmpFile.Name())
+			errStr += " Please find the full response at %v and include it with your ticket on github."
+			return fmt.Errorf(errStr, resp.StatusCode, tmpFile.Name())
 		}
 		return fmt.Errorf(errStr, resp.StatusCode)
 	}

--- a/src/shopify/theme_client_test.go
+++ b/src/shopify/theme_client_test.go
@@ -478,7 +478,7 @@ func TestUnmarshalResponse(t *testing.T) {
 		{input: `{"errors": "Not Found"}`, code: 404, err: "Not Found"},
 		{input: `{"theme":{"id": 123456}}`, code: 200, expected: themeResponse{Theme: Theme{ID: int64(123456)}}},
 		{input: `{"theme":{"id": 123456}}`, code: 200, expected: themeResponse{Theme: Theme{ID: int64(123456)}}},
-		{input: `<html><body>BAD ERROR</body></html>`, code: 500, err: "could not unmarshal JSON from response body on a response with HTTP status 500. This usually means themekit received an html error page. Please find the full response at "},
+		{input: `<html><body>BAD ERROR</body></html>`, code: 500, err: "could not unmarshal JSON from response body on a response with HTTP status 500. This usually means Theme Kit received an HTML error page. Please find the full response at "},
 	}
 
 	for _, testcase := range testcases {

--- a/src/shopify/theme_client_test.go
+++ b/src/shopify/theme_client_test.go
@@ -468,35 +468,6 @@ func TestThemeClient_assetPath(t *testing.T) {
 	}
 }
 
-func TestUnmarshalResponse(t *testing.T) {
-	testcases := []struct {
-		input, err    string
-		code          int
-		out, expected themeResponse
-	}{
-		{input: `{"errors":{"name":["can't be blank"]}}`, code: 200, expected: themeResponse{Errors: map[string][]string{"name": {"can't be blank"}}}},
-		{input: `{"errors": "Not Found"}`, code: 404, err: "Not Found"},
-		{input: `{"theme":{"id": 123456}}`, code: 200, expected: themeResponse{Theme: Theme{ID: int64(123456)}}},
-		{input: `{"theme":{"id": 123456}}`, code: 200, expected: themeResponse{Theme: Theme{ID: int64(123456)}}},
-		{input: `<html><body>BAD ERROR</body></html>`, code: 500, err: "could not unmarshal JSON from response body on a response with HTTP status 500. This usually means Theme Kit received an HTML error page. Please find the full response at "},
-	}
-
-	for _, testcase := range testcases {
-		err := unmarshalResponse(jsonResponse(testcase.input, testcase.code), &testcase.out)
-		assert.Equal(t, testcase.expected, testcase.out)
-		if testcase.err == "" {
-			assert.Nil(t, err)
-		} else if assert.NotNil(t, err) {
-			assert.Contains(t, err.Error(), testcase.err)
-		}
-	}
-
-	out := assetsResponse{}
-	err := unmarshalResponse(jsonResponse(`{"errors":"oh no"}`, 200), &out)
-	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), "oh no")
-}
-
 func TestToMessages(t *testing.T) {
 	testcases := []struct {
 		input    map[string][]string

--- a/src/shopify/theme_client_test.go
+++ b/src/shopify/theme_client_test.go
@@ -478,7 +478,7 @@ func TestUnmarshalResponse(t *testing.T) {
 		{input: `{"errors": "Not Found"}`, code: 404, err: "Not Found"},
 		{input: `{"theme":{"id": 123456}}`, code: 200, expected: themeResponse{Theme: Theme{ID: int64(123456)}}},
 		{input: `{"theme":{"id": 123456}}`, code: 200, expected: themeResponse{Theme: Theme{ID: int64(123456)}}},
-		{input: `<html><body>BAD ERROR</body></html>`, code: 500, err: "could not unmarshal JSON from response body on a response with HTTP status 500"},
+		{input: `<html><body>BAD ERROR</body></html>`, code: 500, err: "could not unmarshal JSON from response body on a response with HTTP status 500. This usually means themekit received an html error page. Please find the full response at "},
 	}
 
 	for _, testcase := range testcases {

--- a/src/shopify/unmarshal.go
+++ b/src/shopify/unmarshal.go
@@ -30,6 +30,7 @@ type RespUnmarshalError struct {
 	Resp       *http.Response
 	Problem    string
 	Suggestion string
+	ReadErr    error
 	TmpFile    *os.File
 }
 
@@ -37,9 +38,9 @@ var respUnmarshalErrorTemplate = template.Must(template.New("respUnmarshalError"
 	`{{ .Problem }}
 {{ .Suggestion }}
 Http Response Status: {{ .Resp.StatusCode }}
-Request ID: {{ .RequestID }}{{with .TmpFile}}
-ResponseBody: {{ .Name }}{{end}}
-`))
+Request ID: {{ .RequestID }}{{ if .ReadErr }}
+Error: {{ .ReadErr }}{{ end }}{{ with .TmpFile }}
+ResponseBody: {{ .Name }}{{ end }}`))
 
 // RequestID is a helper for the template
 func (err RespUnmarshalError) RequestID() string {
@@ -65,6 +66,7 @@ func unmarshalResponse(resp *http.Response, data interface{}) error {
 			Resp:       resp,
 			Problem:    "could not read response body",
 			Suggestion: "This may mean that the request was not able to finish successfully",
+			ReadErr:    err,
 		}
 	}
 	defer resp.Body.Close()

--- a/src/shopify/unmarshal.go
+++ b/src/shopify/unmarshal.go
@@ -1,0 +1,90 @@
+package shopify
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"text/template"
+)
+
+// reqErr is the expected response structure of errors from asset operations.
+type reqErr struct {
+	Errors string `json:"errors"`
+}
+
+// Err will return an error if the struct contains any errors, otherwise it will return nil
+func (err reqErr) Err() error {
+	if len(err.Errors) > 0 {
+		return errors.New(err.Errors)
+	}
+	return nil
+}
+
+// RespUnmarshalError is an error struct to allow us to present response issues
+// in a more intelligent way, and in a way that will make analyzing the errors
+// easier.
+type RespUnmarshalError struct {
+	Resp       *http.Response
+	Problem    string
+	Suggestion string
+	TmpFile    *os.File
+}
+
+var respUnmarshalErrorTemplate = template.Must(template.New("respUnmarshalError").Parse(
+	`{{ .Problem }}
+{{ .Suggestion }}
+Http Response Status: {{ .Resp.StatusCode }}
+Request ID: {{ .RequestID }}{{with .TmpFile}}
+ResponseBody: {{ .Name }}{{end}}
+`))
+
+// RequestID is a helper for the template
+func (err RespUnmarshalError) RequestID() string {
+	return err.Resp.Header.Get("X-Request-Id")
+}
+
+// Error satisfies the Error interface
+func (err RespUnmarshalError) Error() string {
+	var tpl bytes.Buffer
+	respUnmarshalErrorTemplate.Execute(&tpl, err)
+	return tpl.String()
+}
+
+// unmarshalResponse is the bottle neck of receiving an http response and unmarshalling
+// into assets or theme data. If this data cannot be successfully unmarshalled, then
+// it will fallback to try to unmarshal expected error responses in the JSON format.
+// If this finally does not work, then this will return an error of what went wrong
+// and dump the response body into a temporary file for later examination.
+func unmarshalResponse(resp *http.Response, data interface{}) error {
+	reqBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return RespUnmarshalError{
+			Resp:       resp,
+			Problem:    "could not read response body",
+			Suggestion: "This may mean that the request was not able to finish successfully",
+		}
+	}
+	defer resp.Body.Close()
+
+	var re reqErr
+	mainErr := json.Unmarshal(reqBody, data) // check if we can unmarshal into the expected returned data
+	basicErr := json.Unmarshal(reqBody, &re) // if no returned data, check if we can get errors from the body
+	if mainErr != nil && basicErr != nil {
+		tmpFile, err := ioutil.TempFile(os.TempDir(), "themekit-response-*.txt")
+		if err == nil {
+			defer tmpFile.Close()
+			tmpFile.Write([]byte(reqBody))
+		}
+		return RespUnmarshalError{
+			Resp:       resp,
+			Problem:    "could not unmarshal JSON from response body",
+			Suggestion: "This usually means Theme Kit received an HTML error page.",
+			TmpFile:    tmpFile,
+		}
+	}
+
+	return re.Err()
+}

--- a/src/shopify/unmarshal_test.go
+++ b/src/shopify/unmarshal_test.go
@@ -25,9 +25,26 @@ func TestRespUnmarshalError(t *testing.T) {
 	assert.Equal(t, err.Error(), `this is your problem
 test your things
 Http Response Status: 442
-Request ID: abc-123-456
-`)
+Request ID: abc-123-456`)
 
+	err = RespUnmarshalError{
+		Resp:       resp,
+		Problem:    "this is your problem",
+		Suggestion: "test your things",
+		ReadErr:    fmt.Errorf("Bad READ"),
+	}
+
+	assert.Equal(t, err.Error(), `this is your problem
+test your things
+Http Response Status: 442
+Request ID: abc-123-456
+Error: Bad READ`)
+
+	err = RespUnmarshalError{
+		Resp:       resp,
+		Problem:    "this is your problem",
+		Suggestion: "test your things",
+	}
 	err.TmpFile, _ = ioutil.TempFile(os.TempDir(), "themekit-response-*.txt")
 	err.TmpFile.Write([]byte("body"))
 	err.TmpFile.Close()
@@ -37,8 +54,7 @@ Request ID: abc-123-456
 test your things
 Http Response Status: 442
 Request ID: abc-123-456
-ResponseBody: %v
-`, err.TmpFile.Name()))
+ResponseBody: %v`, err.TmpFile.Name()))
 }
 
 func TestUnmarshalResponse(t *testing.T) {

--- a/src/shopify/unmarshal_test.go
+++ b/src/shopify/unmarshal_test.go
@@ -1,0 +1,71 @@
+package shopify
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRespUnmarshalError(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: 442,
+		Header:     http.Header{"X-Request-Id": []string{"abc-123-456"}},
+	}
+
+	err := RespUnmarshalError{
+		Resp:       resp,
+		Problem:    "this is your problem",
+		Suggestion: "test your things",
+	}
+
+	assert.Equal(t, err.Error(), `this is your problem
+test your things
+Http Response Status: 442
+Request ID: abc-123-456
+`)
+
+	err.TmpFile, _ = ioutil.TempFile(os.TempDir(), "themekit-response-*.txt")
+	err.TmpFile.Write([]byte("body"))
+	err.TmpFile.Close()
+	defer os.Remove(err.TmpFile.Name())
+
+	assert.Equal(t, err.Error(), fmt.Sprintf(`this is your problem
+test your things
+Http Response Status: 442
+Request ID: abc-123-456
+ResponseBody: %v
+`, err.TmpFile.Name()))
+}
+
+func TestUnmarshalResponse(t *testing.T) {
+	testcases := []struct {
+		input, err    string
+		code          int
+		out, expected themeResponse
+	}{
+		{input: `{"errors":{"name":["can't be blank"]}}`, code: 200, expected: themeResponse{Errors: map[string][]string{"name": {"can't be blank"}}}},
+		{input: `{"errors": "Not Found"}`, code: 404, err: "Not Found"},
+		{input: `{"theme":{"id": 123456}}`, code: 200, expected: themeResponse{Theme: Theme{ID: int64(123456)}}},
+		{input: `{"theme":{"id": 123456}}`, code: 200, expected: themeResponse{Theme: Theme{ID: int64(123456)}}},
+		{input: `<html><body>BAD ERROR</body></html>`, code: 500, err: "could not unmarshal JSON from response body"},
+	}
+
+	for _, testcase := range testcases {
+		err := unmarshalResponse(jsonResponse(testcase.input, testcase.code), &testcase.out)
+		assert.Equal(t, testcase.expected, testcase.out)
+		if testcase.err == "" {
+			assert.Nil(t, err)
+		} else if assert.NotNil(t, err) {
+			assert.Contains(t, err.Error(), testcase.err)
+		}
+	}
+
+	out := assetsResponse{}
+	err := unmarshalResponse(jsonResponse(`{"errors":"oh no"}`, 200), &out)
+	assert.NotNil(t, err)
+	assert.Equal(t, err.Error(), "oh no")
+}


### PR DESCRIPTION
Related to #631

### Why is this PR needed

Right now, while unmarshalling responses, if the response is not JSON, then themekit will return an unhelpful error of `malformed response` While themekit does not really know what happened, and we have no way of knowing, we can add some more information to help analyze the issue.

### What this PR does

To the main `unmarshalResponse` method that the theme client uses, this adds
- http response status codes to the error messages. This should give us more insight into what the actual response is (500+ status codes)
- flushes the response body to a tempfile, so that it can be included in issue debugging. 
- outputs a path to the tempfile in the error message if flushing was successful.

### Warn Checklist
- [ ] This changes the interface and requires a Major/Minor version change.
- [ ] ~I have :tophat:'d these changes by using the commands I changed by hand.~ it's hard to produce this error.
- [ ] I have added a dependancy to the project.
- [x] I have considered any potential impact on [node-themekit](https://github.com/Shopify/node-themekit)
