### PR TITLE
Allowing python 3 usage

### DIFF
--- a/docs/scripts/install.py
+++ b/docs/scripts/install.py
@@ -7,7 +7,7 @@
     Python Version: 2.7
     Description: Install script for themekit. It will download a release and make it executable
 '''
-import os, urllib, json, sys, hashlib
+import os, json, sys, hashlib
 
 class Installer(object):
     LATEST_RELEASE_URL = "https://shopify-themekit.s3.amazonaws.com/releases/latest.json"
@@ -25,7 +25,7 @@ class Installer(object):
         self.bin_path = "%s/theme" % self.install_path
         self.arch = self.__getArch()
         print("Fetching release data")
-        self.release = json.loads(urllib.urlopen(Installer.LATEST_RELEASE_URL).read().decode("utf-8"))
+        self.release = json.loads(self.__req(Installer.LATEST_RELEASE_URL).decode("utf-8"))
         print("Downloading version %s of Shopify Themekit" % self.release['version'])
         self.__download()
         print("Theme Kit has been installed at %s" % self.bin_path)
@@ -47,7 +47,7 @@ class Installer(object):
 
     def __download(self):
         platform = self.__findReleasePlatform()
-        data = urllib.urlopen(platform['url']).read()
+        data = self.__req(platform['url'])
         if hashlib.md5(data).hexdigest() != platform['digest']:
             sys.exit("Downloaded binary did not match checksum.")
         else:
@@ -58,7 +58,12 @@ class Installer(object):
             themefile.write(data)
         os.chmod(self.bin_path, 0o755)
 
-if sys.version_info[0] < 3:
-    Installer()
-else:
-    sys.exit("Python 2 is required for this script.")
+    def __req(self, url):
+        if sys.version_info[0] < 3:
+            import urllib
+            return urllib.urlopen(url).read()
+        else:
+            import urllib.request
+            return urllib.request.urlopen(url).read()
+
+Installer()

--- a/docs/scripts/install.py
+++ b/docs/scripts/install.py
@@ -9,6 +9,8 @@
 '''
 import os, json, sys, hashlib
 
+from six.moves.urllib.request import urlopen
+
 class Installer(object):
     LATEST_RELEASE_URL = "https://shopify-themekit.s3.amazonaws.com/releases/latest.json"
     ARCH_MAPPING = {
@@ -25,7 +27,7 @@ class Installer(object):
         self.bin_path = "%s/theme" % self.install_path
         self.arch = self.__getArch()
         print("Fetching release data")
-        self.release = json.loads(self.__req(Installer.LATEST_RELEASE_URL).decode("utf-8"))
+        self.release = json.loads(urlopen(Installer.LATEST_RELEASE_URL).read().decode("utf-8"))
         print("Downloading version %s of Shopify Themekit" % self.release['version'])
         self.__download()
         print("Theme Kit has been installed at %s" % self.bin_path)
@@ -47,7 +49,7 @@ class Installer(object):
 
     def __download(self):
         platform = self.__findReleasePlatform()
-        data = self.__req(platform['url'])
+        data = urlopen(platform['url']).read()
         if hashlib.md5(data).hexdigest() != platform['digest']:
             sys.exit("Downloaded binary did not match checksum.")
         else:
@@ -57,13 +59,5 @@ class Installer(object):
         with open(self.bin_path, "wb") as themefile:
             themefile.write(data)
         os.chmod(self.bin_path, 0o755)
-
-    def __req(self, url):
-        if sys.version_info[0] < 3:
-            import urllib
-            return urllib.urlopen(url).read()
-        else:
-            import urllib.request
-            return urllib.request.urlopen(url).read()
 
 Installer()

--- a/docs/scripts/install.py
+++ b/docs/scripts/install.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 '''
-    File name: install
+    File name: install.py
     Author: Tim Anema
     Date created: Sep 29, 2016
-    Date last modified: Sep 14 2018
-    Python Version: 2.7
+    Date last modified: Nov 19 2020
+    Python Version: 2.x, 3.x
     Description: Install script for themekit. It will download a release and make it executable
 '''
 import os, json, sys, hashlib


### PR DESCRIPTION
fixes #725

The installation script only allowed python2 and not python3 but this simple change allows both versions for installation.

Works for both python2 and python3:
![image](https://user-images.githubusercontent.com/463193/99726844-14a05180-2a85-11eb-9515-cae69a80d720.png)

### Warn Checklist
- [ ] This changes the interface and requires a Major/Minor version change.
- [ ] I have :tophat:'d these changes by using the commands I changed by hand.
- [ ] I have added a dependancy to the project.
- [ ] I have considered any potential impact on [node-themekit](https://github.com/Shopify/node-themekit)
