### PR TITLE
Add Homebrew uninstall instructions

### DIFF
--- a/docs/faq/index.md
+++ b/docs/faq/index.md
@@ -40,6 +40,12 @@ command:
 rm $(which theme)
 ```
 
+If you installed Theme Kit through HomeBrew, you can run:
+
+```bash
+brew uninstall themekit
+```
+
 ## Theme Kit does not upload my changes
 
 This usually means that your file is being ignored. Please check your ignore


### PR DESCRIPTION
I noticed that the uninstall instructions are assuming a manual installation, but most people are probably using Homebrew.