### PR TITLE
Change default theme stylesheet from Sass to CSS

### DIFF
--- a/theme-template/assets/application.css.liquid
+++ b/theme-template/assets/application.css.liquid
@@ -1,3 +1,2 @@
 // Put your styles in this file.
-// Shopify will compile SCSS/SASS on each deploy.
 // Note: "@import" rules aren’t supported.


### PR DESCRIPTION
Since Shopify is going to deprecate Sass for Shopify themes, the default stylesheet should change to CSS.
https://www.shopify.com/partners/blog/deprecating-sass

@tanema @chrisbutcher
