### PR TITLE
Fake theme ID in get command for listing

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+v1.1.4
+======
+- Fix for theme get --list (#862)
+
 v1.1.3 (Dec 2, 2020)
 ====================
 - Added an error summary (#826)

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -54,6 +54,7 @@ func getTheme(ctx *cmdutil.Ctx) error {
 }
 
 func listThemes(flags cmdutil.Flags, args []string) error {
+	flags.ThemeID = "1337"
 	themes, err := getDefaultThemes(flags, args)
 	if err != nil {
 		return err


### PR DESCRIPTION
fixes #858 

While changing get, the them ID shim was removed, making the list action require a theme ID, this removes that requirement

### Warn Checklist
- [ ] This changes the interface and requires a Major/Minor version change.
- [ ] I have :tophat:'d these changes by using the commands I changed by hand.
- [ ] I have added a dependancy to the project.
- [ ] I have considered any potential impact on [node-themekit](https://github.com/Shopify/node-themekit)
