### PR TITLE
Remove six lib from install script

### DIFF
--- a/docs/scripts/install.py
+++ b/docs/scripts/install.py
@@ -1,15 +1,13 @@
 #!/usr/bin/env python
 '''
-    File name: install.py
+    File name: install
     Author: Tim Anema
     Date created: Sep 29, 2016
-    Date last modified: Nov 19 2020
-    Python Version: 2.x, 3.x
+    Date last modified: Sep 14 2018
+    Python Version: 2.7
     Description: Install script for themekit. It will download a release and make it executable
 '''
 import os, json, sys, hashlib
-
-from six.moves.urllib.request import urlopen
 
 class Installer(object):
     LATEST_RELEASE_URL = "https://shopify-themekit.s3.amazonaws.com/releases/latest.json"
@@ -27,7 +25,7 @@ class Installer(object):
         self.bin_path = "%s/theme" % self.install_path
         self.arch = self.__getArch()
         print("Fetching release data")
-        self.release = json.loads(urlopen(Installer.LATEST_RELEASE_URL).read().decode("utf-8"))
+        self.release = json.loads(self.__req(Installer.LATEST_RELEASE_URL).decode("utf-8"))
         print("Downloading version %s of Shopify Themekit" % self.release['version'])
         self.__download()
         print("Theme Kit has been installed at %s" % self.bin_path)
@@ -49,7 +47,7 @@ class Installer(object):
 
     def __download(self):
         platform = self.__findReleasePlatform()
-        data = urlopen(platform['url']).read()
+        data = self.__req(platform['url'])
         if hashlib.md5(data).hexdigest() != platform['digest']:
             sys.exit("Downloaded binary did not match checksum.")
         else:
@@ -59,5 +57,13 @@ class Installer(object):
         with open(self.bin_path, "wb") as themefile:
             themefile.write(data)
         os.chmod(self.bin_path, 0o755)
+
+    def __req(self, url):
+        if sys.version_info[0] < 3:
+            import urllib
+            return urllib.urlopen(url).read()
+        else:
+            import urllib.request
+            return urllib.request.urlopen(url).read()
 
 Installer()

--- a/docs/scripts/install.py
+++ b/docs/scripts/install.py
@@ -3,8 +3,8 @@
     File name: install
     Author: Tim Anema
     Date created: Sep 29, 2016
-    Date last modified: Sep 14 2018
-    Python Version: 2.7
+    Date last modified: Dec 3 2020
+    Python Version: 2.x, 3.x
     Description: Install script for themekit. It will download a release and make it executable
 '''
 import os, json, sys, hashlib


### PR DESCRIPTION
fixes #856 

The past change to the install script was cleaner but I thought `six.moves` was a stdlib and it turns out that is incorrect and the script should not have any deps, so I have changed back to this ugly version that does the version switch itself.

### Warn Checklist
- [ ] This changes the interface and requires a Major/Minor version change.
- [ ] I have :tophat:'d these changes by using the commands I changed by hand.
- [ ] I have added a dependancy to the project.
- [ ] I have considered any potential impact on [node-themekit](https://github.com/Shopify/node-themekit)
