### PR TITLE
Taking out my arbitrary timeouts

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 v1.1.4
 ======
 - Fix for theme get --list (#862)
+- Removed too restrictive timeouts (#864)
 
 v1.1.3 (Dec 2, 2020)
 ====================

--- a/src/httpify/client.go
+++ b/src/httpify/client.go
@@ -1,12 +1,10 @@
 package httpify
 
 import (
-	"context"
 	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net"
 	"net/http"
 	"net/url"
 	"runtime"
@@ -23,29 +21,11 @@ var (
 	ErrConnectionIssue = errors.New("DNS problem while connecting to Shopify, this indicates a problem with your internet connection")
 	// ErrInvalidProxyURL is returned if a proxy url has been passed but is improperly formatted
 	ErrInvalidProxyURL = errors.New("invalid proxy URI")
-	netDialer          = &net.Dialer{
-		Timeout:   3 * time.Second,
-		KeepAlive: 1 * time.Second,
-	}
-	httpTransport = &http.Transport{
-		TLSClientConfig:       &tls.Config{InsecureSkipVerify: true},
-		IdleConnTimeout:       time.Second,
-		TLSHandshakeTimeout:   time.Second,
-		ExpectContinueTimeout: time.Second,
-		ResponseHeaderTimeout: time.Second,
-		MaxIdleConnsPerHost:   10,
-		DialContext: func(ctx context.Context, network, address string) (conn net.Conn, err error) {
-			if conn, err = netDialer.DialContext(ctx, network, address); err != nil {
-				return nil, err
-			}
-			deadline := time.Now().Add(5 * time.Second)
-			conn.SetReadDeadline(deadline)
-			return conn, conn.SetDeadline(deadline)
-		},
+	httpTransport      = &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}
 	httpClient = &http.Client{
-		Transport: httpTransport,
-		Timeout:   30 * time.Second,
+		Timeout: 30 * time.Second,
 	}
 )
 
@@ -87,6 +67,7 @@ func NewClient(params Params) (*HTTPClient, error) {
 			return nil, ErrInvalidProxyURL
 		}
 		httpTransport.Proxy = http.ProxyURL(parsedURL)
+		httpClient.Transport = httpTransport
 	}
 
 	return &HTTPClient{
@@ -139,8 +120,12 @@ func (client *HTTPClient) do(method, path string, body interface{}, headers map[
 }
 
 func (client *HTTPClient) doWithRetry(req *http.Request, body interface{}) (*http.Response, error) {
-	var bodyData []byte
-	var err error
+	var (
+		bodyData []byte
+		resp     *http.Response
+		err      error
+	)
+
 	if body != nil {
 		bodyData, err = json.Marshal(body)
 		if err != nil {
@@ -149,7 +134,7 @@ func (client *HTTPClient) doWithRetry(req *http.Request, body interface{}) (*htt
 	}
 
 	for attempt := 0; attempt <= client.maxRetry; attempt++ {
-		resp, err := client.limit.GateReq(httpClient, req, bodyData)
+		resp, err = client.limit.GateReq(httpClient, req, bodyData)
 		if err == nil && resp.StatusCode >= 100 && resp.StatusCode < 500 {
 			return resp, nil
 		} else if strings.Contains(err.Error(), "no such host") {
@@ -157,7 +142,8 @@ func (client *HTTPClient) doWithRetry(req *http.Request, body interface{}) (*htt
 		}
 		time.Sleep(time.Duration(attempt) * time.Second)
 	}
-	return nil, fmt.Errorf("request failed after %v retries", client.maxRetry)
+
+	return nil, fmt.Errorf("request failed after %v retries with error: %v", client.maxRetry, err)
 }
 
 func parseBaseURL(domain string) (*url.URL, error) {

--- a/src/httpify/client.go
+++ b/src/httpify/client.go
@@ -137,7 +137,7 @@ func (client *HTTPClient) doWithRetry(req *http.Request, body interface{}) (*htt
 		resp, err = client.limit.GateReq(httpClient, req, bodyData)
 		if err == nil && resp.StatusCode >= 100 && resp.StatusCode < 500 {
 			return resp, nil
-		} else if strings.Contains(err.Error(), "no such host") {
+		} else if err != nil && strings.Contains(err.Error(), "no such host") {
 			return nil, ErrConnectionIssue
 		}
 		time.Sleep(time.Duration(attempt) * time.Second)


### PR DESCRIPTION
fixes #857 

In previous work, I added in a bunch of arbitrary timeouts, this was because I wanted requests to fail faster if there was an issue. This however was misguided because the actual solution was cancelling the requests. The timeouts were also copied over from our webhook delivery service that I worked on and themekit and that service have vastly different request requirements. Webhook delivery requires fast completion on delivery, however themekit is used to uploading very large files that need more time to complete, so this was done in error.

I have just removed all of these timeouts as the defaults are either pretty large or no timeout is set at all. There is still a general overall request timeout so that does not mean requests will get stuck.

This fix has been confirmed in the issue linked

### Warn Checklist
- [ ] This changes the interface and requires a Major/Minor version change.
- [x] I have :tophat:'d these changes by using the commands I changed by hand.
- [ ] I have added a dependancy to the project.
- [x] I have considered any potential impact on [node-themekit](https://github.com/Shopify/node-themekit)
