### PR TITLE
Allow watch early exit

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@ v1.1.4
 ======
 - Fix for theme get --list (#862)
 - Removed too restrictive timeouts (#864)
+- Allow watch command to be cancelled while working on events (#865)
 
 v1.1.3 (Dec 2, 2020)
 ====================

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -78,13 +78,6 @@ func watch(ctx *cmdutil.Ctx, events chan file.Event, sig chan os.Signal, notifie
 		colors.Yellow(ctx.Env.ThemeID),
 	)
 	for {
-		// non-blocking exit signal check
-		select {
-		case <-sig:
-			return nil
-		default:
-		}
-
 		select {
 		case event := <-events:
 			if event.Path == ctx.Flags.ConfigPath {
@@ -96,10 +89,9 @@ func watch(ctx *cmdutil.Ctx, events chan file.Event, sig chan os.Signal, notifie
 			if event.Op != file.Skip {
 				notifier.notify(ctx, event.Path)
 			}
-		case <-sig: // blocking signal check
+		case <-sig:
 			return nil
 		}
-
 	}
 }
 


### PR DESCRIPTION
fixes #855 

Currently pressing ctrl-C while watch is running will not terminate its execution. This is because the signal channel is unbuffered so signal.Notify cannot write to the channel until it is read and it gets starved in the select statement. I added a buffer of 1 which allows it to be cancelled.

### Warn Checklist
- [ ] This changes the interface and requires a Major/Minor version change.
- [ ] I have :tophat:'d these changes by using the commands I changed by hand.
- [ ] I have added a dependancy to the project.
- [ ] I have considered any potential impact on [node-themekit](https://github.com/Shopify/node-themekit)
