### PR TITLE
Update theme.liquid

### DIFF
--- a/theme-template/layout/theme.liquid
+++ b/theme-template/layout/theme.liquid
@@ -8,7 +8,7 @@
   <link rel="canonical" href="{{ canonical_url }}">
   <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no">
   {{ content_for_header }} <!-- Header hook for plugins -->
-  {{ 'application.scss.css' | asset_url | stylesheet_tag }}
+  {{ 'application.css' | asset_url | stylesheet_tag }}
   {{ 'application.js' | asset_url | script_tag }}
 </head>
 <body>


### PR DESCRIPTION
Removed scss from the default stylesheet filename because it was causing a 404 error.
(related to this commit: https://github.com/Shopify/themekit/commit/9b3a4fb6691accbeacddd093db8a7a91fb64869b)



### Warn Checklist
- [ ] This changes the interface and requires a Major/Minor version change.
- [ ] I have :tophat:'d these changes by using the commands I changed by hand.
- [ ] I have added a dependancy to the project.
- [x] I have considered any potential impact on [node-themekit](https://github.com/Shopify/node-themekit)
