### PR TITLE
finishing up messy release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,25 +20,31 @@ all: clean bundle ## will build a binary for all platforms
 	@export GOOS=freebsd GOARCH=386; $(MAKE) build;
 	@export GOOS=freebsd GOARCH=amd64; $(MAKE) build;
 build:
+	@mkdir -p build/release
 	@mkdir -p build/dist/${GOOS}-${GOARCH} && \
     echo "[${GOOS}-${GOARCH}] build started" && \
 		CGO_ENABLED=0 go build \
 			-ldflags="-s -w" \
 			-o build/dist/${GOOS}-${GOARCH}/theme${EXT} \
 			github.com/Shopify/themekit/cmd/theme && \
+		zip -qj build/release/${GOOS}-${GOARCH}.zip \
+			build/dist/${GOOS}-${GOARCH}/theme${EXT} && \
 		echo "[${GOOS}-${GOARCH}] build complete";
 bundle:
 	@go run src/static/cmd/bundle.go
 sha: ## Generate sha256 for a darwin build for usage with homebrew
 	@shasum -a 256 ./build/dist/darwin-amd64/theme
+
 md5s: ## Generate md5 sums for all builds
-	@echo "darwinamd64sum: $(shell md5 -q ./build/dist/darwin-amd64/theme)"
-	@echo "windows386sum: $(shell md5 -q ./build/dist/windows-386/theme.exe)"
-	@echo "windowsamd64sum: $(shell md5 -q ./build/dist/windows-amd64/theme.exe)"
-	@echo "linux386sum: $(shell md5 -q ./build/dist/linux-386/theme)"
-	@echo "linuxamd64sum: $(shell md5 -q ./build/dist/linux-amd64/theme)"
-	@echo "freebsd386sum: $(shell md5 -q ./build/dist/freebsd-386/theme)"
-	@echo "freebsdamd64sum: $(shell md5 -q ./build/dist/freebsd-amd64/theme)"
+	@echo "| OS      | Architecture | md5 checksums              |"
+	@echo "| :------ | :----------- | :------------------------- |"
+	@echo "| macOS   | 64-bit       | $(shell md5 -q ./build/dist/darwin-amd64/theme)|"
+	@echo "| Windows | 64-bit       | $(shell md5 -q ./build/dist/windows-amd64/theme.exe)|"
+	@echo "| Windows | 32-bit       | $(shell md5 -q ./build/dist/windows-386/theme.exe)|"
+	@echo "| Linux   | 64-bit       | $(shell md5 -q ./build/dist/linux-amd64/theme)|"
+	@echo "| Linux   | 32-bit       | $(shell md5 -q ./build/dist/linux-386/theme)|"
+	@echo "| FreeBSD | 64-bit       | $(shell md5 -q ./build/dist/freebsd-amd64/theme)|"
+	@echo "| FreeBSD | 32-bit       | $(shell md5 -q ./build/dist/freebsd-386/theme)|"
 help:
 	@grep -E '^[a-zA-Z_0-9-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
 		sort | \

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ build:
 			-ldflags="-s -w" \
 			-o build/dist/${GOOS}-${GOARCH}/theme${EXT} \
 			github.com/Shopify/themekit/cmd/theme && \
-		zip -qj build/release/${GOOS}-${GOARCH}.zip \
+		zip --quiet --junk-paths build/release/${GOOS}-${GOARCH}.zip \
 			build/dist/${GOOS}-${GOARCH}/theme${EXT} && \
 		echo "[${GOOS}-${GOARCH}] build complete";
 bundle:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -23,7 +23,8 @@ To release a new version of Theme Kit, make sure to complete all of the followin
 1. In GitHub, create a new release for the tag.
 2. Include a brief summary of all the changes pertaining to the release.
 3. Include links to the pull requests that introduced the changes.
-4. Upload the binary files, include the md5(`make md5s`) checksums, and changes in the description.
+4. Include the md5(`make md5s`) checksums in the description.
+5. Upload the zipped binary files from `build/release`.
 
 ## 4. Update the Theme Kit documentation on shopify.dev
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -23,7 +23,7 @@ To release a new version of Theme Kit, make sure to complete all of the followin
 1. In GitHub, create a new release for the tag.
 2. Include a brief summary of all the changes pertaining to the release.
 3. Include links to the pull requests that introduced the changes.
-4. Upload the binary files and include the md5 checksums in the description.
+4. Upload the binary files, include the md5(`make md5s`) checksums, and changes in the description.
 
 ## 4. Update the Theme Kit documentation on shopify.dev
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+v1.1.6 (Feb 3, 2021)
+=====================
+- Allow theme get and theme new to use env vars https://github.com/Shopify/themekit/pull/891
+- Fixed errors from directory changes in theme watch https://github.com/Shopify/themekit/pull/889
+
 v1.1.5 (Jan 21, 2021)
 =====================
 - Fix layout after renaming application.scss.css to application.css

--- a/src/release/release.go
+++ b/src/release/release.go
@@ -30,7 +30,7 @@ var (
 		"windows-amd64": "theme.exe",
 	}
 	// ThemeKitVersion is the version build of the library
-	ThemeKitVersion, _ = version.NewVersion("1.1.5")
+	ThemeKitVersion, _ = version.NewVersion("1.1.6")
 )
 
 const (


### PR DESCRIPTION
I release 1.1.6 for the doc changes but forgot to include the changelog updates and change the version number on main first. This was a mess.

After releasing in this new process. I have updated the releasing document to reflect what I had to do, as well as changed makefile commands to make releasing easier.

You can now see what the new releases look like with the included sums https://github.com/Shopify/themekit/releases/tag/v1.1.6

### Warn Checklist
- [ ] This changes the interface and requires a Major/Minor version change.
- [ ] I have :tophat:'d these changes by using the commands I changed by hand.
- [ ] I have added a dependancy to the project.
- [ ] I have considered any potential impact on [node-themekit](https://github.com/Shopify/node-themekit)
