### PR TITLE
Add redirects for deep links

### DIFF
--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -1,0 +1,4 @@
+---
+title: Command reference
+redirect_to: https://shopify.dev/tools/theme-kit/command-reference
+---

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -1,0 +1,4 @@
+---
+title: Configuration reference
+redirect_to: https://shopify.dev/tools/theme-kit/configuration-reference
+---

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -1,0 +1,4 @@
+---
+title: Developing Theme Kit
+redirect_to: https://github.com/Shopify/themekit/blob/master/CONTRIBUTING.md
+---

--- a/docs/faq/index.md
+++ b/docs/faq/index.md
@@ -1,0 +1,4 @@
+---
+title: Troubleshooting
+redirect_to: https://shopify.dev/tools/theme-kit/troubleshooting
+---


### PR DESCRIPTION
## This PR: 
- Adds redirects for deep links associated with Theme Kit pages (configuration reference, command reference, developing theme kit, and troubleshooting)
- Relates to https://github.com/Shopify/themekit/issues/899