### PR TITLE
Redirect https://shopify.github.io/themekit/ignores/

### DIFF
--- a/docs/ignores/index.md
+++ b/docs/ignores/index.md
@@ -1,0 +1,4 @@
+---
+title: Configuration reference
+redirect_to: https://shopify.dev/tools/theme-kit/configuration-reference
+---


### PR DESCRIPTION
## This PR: 
- Redirects https://shopify.github.io/themekit/ignores/ to the configuration reference on shopify.dev.
- Relates to https://github.com/Shopify/themekit/issues/899 and https://github.com/Shopify/shopify-dev/issues/5032