### PR TITLE
Add dev.yml

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Although Theme Kit is a command line interface, it's also a library that can be 
 
 ### Requirements
 
-- Go 1.12 or higher
+- Go 1.13 or higher
 - [Golint](https://github.com/golang/lint)
 
 ### Set up your development environment

--- a/dev.yml
+++ b/dev.yml
@@ -5,6 +5,7 @@ type: go
 up:
   - homebrew:
     - mitmproxy
+    - dep
   - go:
       version: 1.13
       modules: true

--- a/dev.yml
+++ b/dev.yml
@@ -3,6 +3,8 @@ name: themekit
 type: go
 
 up:
+  - homebrew:
+    - mitmproxy
   - go:
       version: 1.13
       modules: true

--- a/dev.yml
+++ b/dev.yml
@@ -1,0 +1,8 @@
+name: themekit
+
+type: go
+
+up:
+  - go:
+      version: 1.13
+      modules: true


### PR DESCRIPTION
This allows Shopifolk to set up the app for development by running `dev up`.