### PR TITLE
Add redirect to ThemeKit Access when password prefix matches pattern

### DIFF
--- a/src/httpify/client.go
+++ b/src/httpify/client.go
@@ -15,6 +15,8 @@ import (
 	"github.com/Shopify/themekit/src/release"
 )
 
+const themeKitPasswordPrefix = "shptka_"
+
 var (
 	// ErrConnectionIssue is an error that is thrown when a very specific error is
 	// returned from our http request that usually implies bad connections.
@@ -43,12 +45,11 @@ type Params struct {
 // HTTPClient encapsulates an authenticate http client to issue theme requests
 // to Shopify
 type HTTPClient struct {
-	domain            string
-	password          string
-	baseURL           *url.URL
-	limit             *ratelimiter.Limiter
-	maxRetry          int
-	themeKitAccessURL string
+	domain   string
+	password string
+	baseURL  *url.URL
+	limit    *ratelimiter.Limiter
+	maxRetry int
 }
 
 // NewClient will create a new authenticated http client that will communicate
@@ -73,12 +74,11 @@ func NewClient(params Params) (*HTTPClient, error) {
 	}
 
 	return &HTTPClient{
-		domain:            params.Domain,
-		password:          params.Password,
-		baseURL:           baseURL,
-		limit:             ratelimiter.New(params.Domain, 4),
-		maxRetry:          5,
-		themeKitAccessURL: themeKitAccessURL,
+		domain:   params.Domain,
+		password: params.Password,
+		baseURL:  baseURL,
+		limit:    ratelimiter.New(params.Domain, 4),
+		maxRetry: 5,
 	}, nil
 }
 
@@ -107,11 +107,10 @@ func (client *HTTPClient) Delete(path string, headers map[string]string) (*http.
 // do will issue an authenticated json request to shopify.
 func (client *HTTPClient) do(method, path string, body interface{}, headers map[string]string) (*http.Response, error) {
 	appBaseURL := client.baseURL.String()
-	themeKitPasswordPrefix := "shptka_"
 
 	// redirect to Theme Kit Access
 	if strings.HasPrefix(client.password, themeKitPasswordPrefix) {
-		appBaseURL = client.themeKitAccessURL
+		appBaseURL = themeKitAccessURL
 	}
 
 	req, err := http.NewRequest(method, appBaseURL+path, nil)

--- a/src/httpify/client_test.go
+++ b/src/httpify/client_test.go
@@ -141,6 +141,50 @@ func TestClient_do(t *testing.T) {
 	_, err = client.do("POST", "/assets.json", body, nil)
 	assert.Contains(t, err.Error(), "request failed after 1 retries", server.URL)
 	server.Close()
+
+	// Client should query Theme Kit Access server instead of Shopify when password starts with a prefix "shptka_"
+	shopifyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+
+	themeKitAccessServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Header.Get("X-Shopify-Shop"), client.domain)
+	}))
+
+	client, err = NewClient(Params{
+		Domain:   shopifyServer.URL,
+		Password: "shptka_00000000000000000000000000000000",
+	})
+	client.themeKitAccessURL = themeKitAccessServer.URL
+
+	assert.NotNil(t, client)
+	assert.Nil(t, err)
+
+	resp, err = client.Post("/assets.json", body, map[string]string{"X-Custom-Header": "Checksum"})
+	assert.Nil(t, err)
+	assert.NotNil(t, resp)
+
+	server.Close()
+
+	// Client should query Shopify instead of Theme Kit Access server when password has no specified prefix
+	shopifyServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Empty(t, r.Header.Get("X-Shopify-Shop"))
+	}))
+
+	themeKitAccessServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+
+	client, err = NewClient(Params{
+		Domain:   shopifyServer.URL,
+		Password: "secret_password",
+	})
+	client.themeKitAccessURL = themeKitAccessServer.URL
+
+	assert.NotNil(t, client)
+	assert.Nil(t, err)
+
+	resp, err = client.Post("/assets.json", body, map[string]string{"X-Custom-Header": "Checksum"})
+	assert.Nil(t, err)
+	assert.NotNil(t, resp)
+
+	server.Close()
 }
 
 func TestGenerateHTTPAdapter(t *testing.T) {

--- a/src/httpify/client_test.go
+++ b/src/httpify/client_test.go
@@ -153,7 +153,7 @@ func TestClient_do(t *testing.T) {
 		Domain:   shopifyServer.URL,
 		Password: "shptka_00000000000000000000000000000000",
 	})
-	client.themeKitAccessURL = themeKitAccessServer.URL
+	themeKitAccessURL = themeKitAccessServer.URL
 
 	assert.NotNil(t, client)
 	assert.Nil(t, err)
@@ -175,7 +175,7 @@ func TestClient_do(t *testing.T) {
 		Domain:   shopifyServer.URL,
 		Password: "secret_password",
 	})
-	client.themeKitAccessURL = themeKitAccessServer.URL
+	themeKitAccessURL = themeKitAccessServer.URL
 
 	assert.NotNil(t, client)
 	assert.Nil(t, err)


### PR DESCRIPTION
**Description**
Themekit needs to make requests either to ThemeKit Access or to Shopify depending on the type of password token that user has. This should have no effect for existing Themekit users.

The solution checks whether user token starts with an identifiable prefix `shptka_` and redirect all requests to the Theme Kit Access server.

**Additional context**
The issue is related to the new public ThemeKit Access app development.

### Warn Checklist
- [x] This changes the interface and requires a Major/Minor version change.
- [x] I have :tophat:'d these changes by using the commands I changed by hand.
- [ ] I have added a dependancy to the project.
- [ ] I have considered any potential impact on [node-themekit](https://github.com/Shopify/node-themekit)
