### PR TITLE
Update ThemeKit version and changelog for new release

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+v1.2.0 (May 27, 2021)
+=====================
+- Add support for Theme Kit access https://github.com/Shopify/themekit/pull/933
+
 v1.1.6 (Feb 3, 2021)
 =====================
 - Allow theme get and theme new to use env vars https://github.com/Shopify/themekit/pull/891

--- a/src/release/release.go
+++ b/src/release/release.go
@@ -30,7 +30,7 @@ var (
 		"windows-amd64": "theme.exe",
 	}
 	// ThemeKitVersion is the version build of the library
-	ThemeKitVersion, _ = version.NewVersion("1.1.6")
+	ThemeKitVersion, _ = version.NewVersion("1.2.0")
 )
 
 const (


### PR DESCRIPTION
Updating to v1.2.0. The new version will be compatible with the Theme Kit access app.

### Warn Checklist
- [ ] This changes the interface and requires a Major/Minor version change.
- [ ] I have :tophat:'d these changes by using the commands I changed by hand.
- [ ] I have added a dependancy to the project.
- [ ] I have considered any potential impact on [node-themekit](https://github.com/Shopify/node-themekit)
