### PR TITLE
Add messaging Theme Kit Access messaging and flag to suppress it

### DIFF
--- a/src/cmdutil/util.go
+++ b/src/cmdutil/util.go
@@ -30,33 +30,34 @@ var (
 // Flags encapsulates all the possible flags that can be set in the themekit
 // command line. Some of the values are used across different commands
 type Flags struct {
-	ConfigPath            string
-	VariableFilePath      string
-	Environments          []string
-	Directory             string
-	Password              string
-	ThemeID               string
-	Domain                string
-	Proxy                 string
-	Timeout               time.Duration
-	Verbose               bool
-	DisableUpdateNotifier bool
-	IgnoredFiles          []string
-	Ignores               []string
-	DisableIgnore         bool
-	Notify                string
-	AllEnvs               bool
-	Version               string
-	Prefix                string
-	URL                   string
-	Name                  string
-	Edit                  bool
-	With                  string
-	List                  bool
-	NoDelete              bool
-	AllowLive             bool
-	Live                  bool
-	HidePreviewBar        bool
+	ConfigPath                    string
+	VariableFilePath              string
+	Environments                  []string
+	Directory                     string
+	Password                      string
+	ThemeID                       string
+	Domain                        string
+	Proxy                         string
+	Timeout                       time.Duration
+	Verbose                       bool
+	DisableUpdateNotifier         bool
+	IgnoredFiles                  []string
+	Ignores                       []string
+	DisableIgnore                 bool
+	Notify                        string
+	AllEnvs                       bool
+	Version                       string
+	Prefix                        string
+	URL                           string
+	Name                          string
+	Edit                          bool
+	With                          string
+	List                          bool
+	NoDelete                      bool
+	AllowLive                     bool
+	Live                          bool
+	HidePreviewBar                bool
+	DisableThemeKitAccessNotifier bool
 }
 
 // Ctx is a specific context that a command will run in

--- a/src/httpify/client.go
+++ b/src/httpify/client.go
@@ -13,9 +13,8 @@ import (
 
 	"github.com/Shopify/themekit/src/ratelimiter"
 	"github.com/Shopify/themekit/src/release"
+	"github.com/Shopify/themekit/src/util"
 )
-
-const themeKitPasswordPrefix = "shptka_"
 
 var (
 	// ErrConnectionIssue is an error that is thrown when a very specific error is
@@ -109,7 +108,7 @@ func (client *HTTPClient) do(method, path string, body interface{}, headers map[
 	appBaseURL := client.baseURL.String()
 
 	// redirect to Theme Kit Access
-	if strings.HasPrefix(client.password, themeKitPasswordPrefix) {
+	if util.IsThemeKitAccessPassword(client.password) {
 		appBaseURL = themeKitAccessURL
 	}
 
@@ -123,7 +122,7 @@ func (client *HTTPClient) do(method, path string, body interface{}, headers map[
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Accept", "application/json")
 	req.Header.Add("User-Agent", fmt.Sprintf("go/themekit (%s; %s; %s)", runtime.GOOS, runtime.GOARCH, release.ThemeKitVersion.String()))
-	if strings.HasPrefix(client.password, themeKitPasswordPrefix) {
+	if util.IsThemeKitAccessPassword(client.password) {
 		req.Header.Add("X-Shopify-Shop", client.domain)
 	}
 	for label, value := range headers {

--- a/src/util/themekit_access.go
+++ b/src/util/themekit_access.go
@@ -1,0 +1,9 @@
+package util
+
+import "strings"
+
+// IsThemeKitAccessPassword checks if the password is a Theme Kit Access password
+func IsThemeKitAccessPassword(password string) bool {
+	themeKitPasswordPrefix := "shptka_"
+	return strings.HasPrefix(password, themeKitPasswordPrefix)
+}

--- a/src/util/themekit_access_test.go
+++ b/src/util/themekit_access_test.go
@@ -1,0 +1,15 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsThemeKitAccessPassword(t *testing.T) {
+	themeKitAccessPassword := "shptka_00000000000000000000000000000000"
+	assert.True(t, IsThemeKitAccessPassword(themeKitAccessPassword))
+
+	privateAppPassword := "shp_00000000000000000000000000000000"
+	assert.False(t, IsThemeKitAccessPassword(privateAppPassword))
+}


### PR DESCRIPTION
The Theme Kit Access app is in beta now. When we move to GA, we want to encourage developers to make the switch by adding messaging to the Theme Kit CLI. This PR adds that message and a flag to be able to suppress it.

Part of https://github.com/Shopify/themekit-access/issues/147

### Warn Checklist
- [x] This changes the interface and requires a Major/Minor version change.
- [x] I have :tophat:'d these changes by using the commands I changed by hand.
- [ ] I have added a dependancy to the project.
- [ ] I have considered any potential impact on [node-themekit](https://github.com/Shopify/node-themekit)
