### PR TITLE
Rename to .env

### DIFF
--- a/src/env/conf.go
+++ b/src/env/conf.go
@@ -18,7 +18,7 @@ import (
 const (
 	vendor   = "Shopify"
 	appname  = "Themekit"
-	filename = "variables"
+	filename = ".env"
 )
 
 var (


### PR DESCRIPTION
Let's just use an actual `.env` file instead of creating a new file.

Closes #942 

### Warn Checklist
- [x] This changes the interface and requires a Major/Minor version change.
- [ ] I have :tophat:'d these changes by using the commands I changed by hand.
- [ ] I have added a dependancy to the project.
- [x] I have considered any potential impact on [node-themekit](https://github.com/Shopify/node-themekit)
