### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You can install Theme Kit using the command line on the following operating syst
 If you want to integrate Theme Kit into your build process, then you can run the following `npm` command to install the [Node wrapper](https://github.com/Shopify/node-themekit) around Theme Kit:
 
 ``` terminal
-$ npm install themekit
+$ npm install @shopify/themekit
 ```
 
 ## Reference guides


### PR DESCRIPTION
Correct npm package name for the Shopify themekit node wrapper is @shopify/themekit



### Warn Checklist
- [ ] This changes the interface and requires a Major/Minor version change.
- [ ] I have :tophat:'d these changes by using the commands I changed by hand.
- [ ] I have added a dependancy to the project.
- [ ] I have considered any potential impact on [node-themekit](https://github.com/Shopify/node-themekit)
