### PR TITLE
Rename Theme Kit Access references to Theme Access

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,10 +1,10 @@
 v1.3.0 (Jun 23, 2021)
 =====================
-- Add messaging for Theme Kit access https://github.com/Shopify/themekit/pull/939
+- Add messaging for Theme Access https://github.com/Shopify/themekit/pull/939
 
 v1.2.0 (May 27, 2021)
 =====================
-- Add support for Theme Kit access https://github.com/Shopify/themekit/pull/933
+- Add support for Theme Access https://github.com/Shopify/themekit/pull/933
 
 v1.1.6 (Feb 3, 2021)
 =====================

--- a/cmd/theme.go
+++ b/cmd/theme.go
@@ -49,8 +49,8 @@ Complete documentation is available at https://shopify.dev/tools/theme-kit.`,
 				flags.ThemeID = "1337"
 			}
 			cmdutil.ForDefaultClient(flags, args, func(ctx *cmdutil.Ctx) error {
-				if !flags.DisableThemeKitAccessNotifier && !util.IsThemeKitAccessPassword(ctx.Env.Password) {
-					colors.ColorStdOut.Print(colors.Yellow("* Build themes without private apps. Learn more about the Theme Kit Access app: https://shopify.dev/tools/theme-kit/manage-theme-kit-access"))
+				if !flags.DisableThemeKitAccessNotifier && !util.IsThemeAccessPassword(ctx.Env.Password) {
+					colors.ColorStdOut.Print(colors.Yellow("* Build themes without private apps. Learn more about the Theme Access app: https://shopify.dev/themes/tools/theme-access"))
 				}
 				return nil
 			})
@@ -102,7 +102,7 @@ func init() {
 	ThemeCmd.PersistentFlags().StringArrayVar(&flags.Ignores, "ignores", []string{}, "A path to a file that contains ignore patterns.")
 	ThemeCmd.PersistentFlags().BoolVar(&flags.DisableIgnore, "no-ignore", false, "Will disable config ignores so that all files can be changed")
 	ThemeCmd.PersistentFlags().BoolVar(&flags.AllowLive, "allow-live", false, "Will allow themekit to make changes to the live theme on the store.")
-	ThemeCmd.PersistentFlags().BoolVarP(&flags.DisableThemeKitAccessNotifier, "no-theme-kit-access-notifier", "", false, "Stop theme kit from notifying about Theme Kit Access.")
+	ThemeCmd.PersistentFlags().BoolVarP(&flags.DisableThemeKitAccessNotifier, "no-theme-kit-access-notifier", "", false, "Stop theme kit from notifying about Theme Access.")
 
 	watchCmd.Flags().StringVarP(&flags.Notify, "notify", "n", "", "file to touch or url to notify when a file has been changed")
 	watchCmd.Flags().BoolVarP(&flags.AllEnvs, "allenvs", "a", false, "run command with all environments")

--- a/src/httpify/client.go
+++ b/src/httpify/client.go
@@ -107,8 +107,8 @@ func (client *HTTPClient) Delete(path string, headers map[string]string) (*http.
 func (client *HTTPClient) do(method, path string, body interface{}, headers map[string]string) (*http.Response, error) {
 	appBaseURL := client.baseURL.String()
 
-	// redirect to Theme Kit Access
-	if util.IsThemeKitAccessPassword(client.password) {
+	// redirect to Theme Access
+	if util.IsThemeAccessPassword(client.password) {
 		appBaseURL = themeKitAccessURL
 	}
 
@@ -122,7 +122,7 @@ func (client *HTTPClient) do(method, path string, body interface{}, headers map[
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Accept", "application/json")
 	req.Header.Add("User-Agent", fmt.Sprintf("go/themekit (%s; %s; %s)", runtime.GOOS, runtime.GOARCH, release.ThemeKitVersion.String()))
-	if util.IsThemeKitAccessPassword(client.password) {
+	if util.IsThemeAccessPassword(client.password) {
 		req.Header.Add("X-Shopify-Shop", client.domain)
 	}
 	for label, value := range headers {

--- a/src/httpify/client_test.go
+++ b/src/httpify/client_test.go
@@ -142,7 +142,7 @@ func TestClient_do(t *testing.T) {
 	assert.Contains(t, err.Error(), "request failed after 1 retries", server.URL)
 	server.Close()
 
-	// Client should query Theme Kit Access server instead of Shopify when password starts with a prefix "shptka_"
+	// Client should query Theme Access server instead of Shopify when password starts with a prefix "shptka_"
 	shopifyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 
 	themeKitAccessServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -164,7 +164,7 @@ func TestClient_do(t *testing.T) {
 
 	server.Close()
 
-	// Client should query Shopify instead of Theme Kit Access server when password has no specified prefix
+	// Client should query Shopify instead of Theme Access server when password has no specified prefix
 	shopifyServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Empty(t, r.Header.Get("X-Shopify-Shop"))
 	}))

--- a/src/util/themekit_access.go
+++ b/src/util/themekit_access.go
@@ -2,8 +2,8 @@ package util
 
 import "strings"
 
-// IsThemeKitAccessPassword checks if the password is a Theme Kit Access password
-func IsThemeKitAccessPassword(password string) bool {
+// IsThemeAccessPassword checks if the password is a Theme Access password
+func IsThemeAccessPassword(password string) bool {
 	themeKitPasswordPrefix := "shptka_"
 	return strings.HasPrefix(password, themeKitPasswordPrefix)
 }

--- a/src/util/themekit_access_test.go
+++ b/src/util/themekit_access_test.go
@@ -6,10 +6,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestIsThemeKitAccessPassword(t *testing.T) {
+func TestIsThemeAccessPassword(t *testing.T) {
 	themeKitAccessPassword := "shptka_00000000000000000000000000000000"
-	assert.True(t, IsThemeKitAccessPassword(themeKitAccessPassword))
+	assert.True(t, IsThemeAccessPassword(themeKitAccessPassword))
 
 	privateAppPassword := "shp_00000000000000000000000000000000"
-	assert.False(t, IsThemeKitAccessPassword(privateAppPassword))
+	assert.False(t, IsThemeAccessPassword(privateAppPassword))
 }


### PR DESCRIPTION
Part of https://github.com/Shopify/shopify-cli-planning/issues/364

### Warn Checklist
- [ ] This changes the interface and requires a Major/Minor version change.
- [x] I have :tophat:'d these changes by using the commands I changed by hand.
- [ ] I have added a dependancy to the project.
- [x] I have considered any potential impact on [node-themekit](https://github.com/Shopify/node-themekit)
