### PR TITLE
Release 1.3.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,6 @@ clean: ## Remove all temporary build artifacts
 all: clean bundle ## will build a binary for all platforms
 	@export GOOS=windows GOARCH=386 EXT=.exe; $(MAKE) build;
 	@export GOOS=windows GOARCH=amd64 EXT=.exe; $(MAKE) build;
-	@export GOOS=darwin GOARCH=386; $(MAKE) build;
 	@export GOOS=darwin GOARCH=amd64; $(MAKE) build;
 	@export GOOS=linux GOARCH=386; $(MAKE) build;
 	@export GOOS=linux GOARCH=amd64; $(MAKE) build;

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+v1.3.1 (Dec 12, 2022)
+=====================
+- Rename Theme Kit Access references to Theme Access https://github.com/Shopify/themekit/pull/984
+
 v1.3.0 (Jun 23, 2021)
 =====================
 - Add messaging for Theme Access https://github.com/Shopify/themekit/pull/939

--- a/choco/themekit.nuspec
+++ b/choco/themekit.nuspec
@@ -2,17 +2,17 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>themekit</id>
-    <version>1.2.0</version>
+    <version>1.3.1</version>
     <packageSourceUrl>https://github.com/Shopify/themekit/blob/master/choco</packageSourceUrl>
     <owners>Shopify</owners>
     <title>Shopify Themekit</title>
     <authors>Tim Anema</authors>
-    <projectUrl>https://shopify.github.io/themekit/</projectUrl>
-    <iconUrl>https://shopify.github.io/themekit/choco_assets/shopify-logo.png</iconUrl>
+    <projectUrl>https://shopify.dev/themes/tools/theme-kit/</projectUrl>
+    <iconUrl>https://cdn.shopifycdn.net/static/images/logos/shopify-bag.png</iconUrl>
     <copyright>Shopify 2019</copyright>
     <licenseUrl>https://github.com/Shopify/themekit/blob/master/LICENSE</licenseUrl>
     <projectSourceUrl>https://github.com/Shopify/themekit</projectSourceUrl>
-    <docsUrl>https://shopify.dev/tools/theme-kit</docsUrl>
+    <docsUrl>https://shopify.dev/themes/tools/theme-kit/</docsUrl>
     <bugTrackerUrl>https://github.com/Shopify/themekit/issues</bugTrackerUrl>
     <tags>themekit shopify</tags>
     <summary>Theme Kit is a command line tool for shopify themes.</summary>

--- a/choco/tools/chocolateyinstall.ps1
+++ b/choco/tools/chocolateyinstall.ps1
@@ -2,11 +2,11 @@
 $toolsDir       = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $packageName    = $env:ChocolateyPackageName
 $file           = "$($toolsDir)\theme.exe"
-$version        = "v1.2.0"
+$version        = "v1.3.1"
 $url            = "https://shopify-themekit.s3.amazonaws.com/$($version)/windows-386/theme.exe"
 $url64          = "https://shopify-themekit.s3.amazonaws.com/$($version)/windows-amd64/theme.exe"
-$checksum       = '827727f12600cdc8f248029c36486d43'
-$checksum64     = '7e407fe95e4124d1b3e99b66799f3fd9'
+$checksum       = '20292407e05210e43dd2a4ee0e660321'
+$checksum64     = '8541545ada519c5a9f780b7eb05b5c02'
 $validExitCodes = @(0)
 
 Get-ChocolateyWebFile `

--- a/dev.yml
+++ b/dev.yml
@@ -7,5 +7,5 @@ up:
     - mitmproxy
     - dep
   - go:
-      version: 1.13
+      version: 1.17.13
       modules: true

--- a/docs/scripts/install.py
+++ b/docs/scripts/install.py
@@ -13,7 +13,6 @@ class Installer(object):
     LATEST_RELEASE_URL = "https://shopify-themekit.s3.amazonaws.com/releases/latest.json"
     ARCH_MAPPING = {
         "darwin x86_64": "darwin-amd64",
-        "darwin i386": "darwin-386",
         "linux x86_64": "linux-amd64",
         "linux i386": "linux-386",
         "freebsd x86_64": "freebsd-amd64",

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -13,7 +13,6 @@ class Installer(object):
     LATEST_RELEASE_URL = "https://shopify-themekit.s3.amazonaws.com/releases/latest.json"
     ARCH_MAPPING = {
         "darwin x86_64": "darwin-amd64",
-        "darwin i386": "darwin-386",
         "linux x86_64": "linux-amd64",
         "linux i386": "linux-386",
         "freebsd x86_64": "freebsd-amd64",

--- a/src/release/release.go
+++ b/src/release/release.go
@@ -30,7 +30,7 @@ var (
 		"windows-amd64": "theme.exe",
 	}
 	// ThemeKitVersion is the version build of the library
-	ThemeKitVersion, _ = version.NewVersion("1.3.0")
+	ThemeKitVersion, _ = version.NewVersion("1.3.1")
 )
 
 const (

--- a/src/release/release.go
+++ b/src/release/release.go
@@ -21,7 +21,6 @@ import (
 var (
 	builds = map[string]string{
 		"darwin-amd64":  "theme",
-		"darwin-386":    "theme",
 		"linux-386":     "theme",
 		"linux-amd64":   "theme",
 		"freebsd-386":   "theme",

--- a/src/release/release_test.go
+++ b/src/release/release_test.go
@@ -282,7 +282,6 @@ func TestBuildRelease(t *testing.T) {
 
 	testplatforms := []platform{
 		{Name: "darwin-amd64", URL: "http://amazon/themekit", Digest: "d41d8cd98f00b204e9800998ecf8427e"},
-		{Name: "darwin-386", URL: "http://amazon/themekit", Digest: "d41d8cd98f00b204e9800998ecf8427e"},
 		{Name: "linux-386", URL: "http://amazon/themekit", Digest: "d41d8cd98f00b204e9800998ecf8427e"},
 		{Name: "linux-amd64", URL: "http://amazon/themekit", Digest: "d41d8cd98f00b204e9800998ecf8427e"},
 		{Name: "windows-386", URL: "http://amazon/themekit", Digest: "d41d8cd98f00b204e9800998ecf8427e"},


### PR DESCRIPTION
Besides updating the version and changelog, I had to make 2 additional changes:
- Upgrade Go, because [1.13 is no longer supported from Homebrew since July](https://formulae.brew.sh/formula/go@1.13)
- Drop support for darwin-386, as [Go doesn't support it since 1.15](https://go.dev/doc/go1.15#386)

### Warn Checklist
- [ ] This changes the interface and requires a Major/Minor version change.
- [x] I have :tophat:'d these changes by using the commands I changed by hand.
- [ ] I have added a dependancy to the project.
- [x] I have considered any potential impact on [node-themekit](https://github.com/Shopify/node-themekit)
